### PR TITLE
Adding Prometheus Rule for Dead Man's Snitch API Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ metricDeadMansSnitchHeartbeat: Every 5 minutes, makes a request to the Dead Man'
 
 ## Alerts
 
-Creates an alert when metricDeadMansSnitchHeartbeat is 0 for 15 minutes.
+- DeadMansSnitchAPIUnavailable - Unable to communicate with Dead Man's Snitch API for 15 minutes.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@
 Operator to manage deadmanssnitch configs for Openshift Dedicated
 
 ## Metrics
+
 metricDeadMansSnitchHeartbeat: Every 5 minutes, makes a request to the Dead Man's Switch API using the API key and updates the gauge to 1 when the response code is between 200-299.
+
+## Alerts
+
+Creates an alert when metricDeadMansSnitchHeartbeat is 0 for 15 minutes.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# deadmanssnitch-operator
+
+Operator to manage deadmanssnitch configs for Openshift Dedicated
+
+## Metrics
+metricDeadMansSnitchHeartbeat: Every 5 minutes, makes a request to the Dead Man's Switch API using the API key and updates the gauge to 1 when the response code is between 200-299.

--- a/deploy/prometheus-k8s-rules.yaml
+++ b/deploy/prometheus-k8s-rules.yaml
@@ -15,3 +15,4 @@ spec:
       for: 15m
       labels:
         severity: critical
+        

--- a/deploy/prometheus-k8s-rules.yaml
+++ b/deploy/prometheus-k8s-rules.yaml
@@ -10,7 +10,6 @@ spec:
     - alert: Unable to communicate with Dead Man's Snitch
       annotations:
         message: "Unable to communicate with Dead Man's Snitch"
-        link_url: "addsomeurlhe.re"
       expr: metricDeadMansSnitchHeartbeat = 0
       for: 15m
       labels:

--- a/deploy/prometheus-k8s-rules.yaml
+++ b/deploy/prometheus-k8s-rules.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: deadmanssnitch-operator
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: deadmanssnitch-operator
+    rules:
+    - alert: Unable to communicate with Dead Man's Snitch
+      annotations:
+        message: "Unable to communicate with Dead Man's Snitch"
+        link_url: "addsomeurlhe.re"
+      expr: metricDeadMansSnitchHeartbeat = 0
+      for: 15m
+      labels:
+        severity: critical

--- a/deploy/prometheus-k8s-rules.yaml
+++ b/deploy/prometheus-k8s-rules.yaml
@@ -7,7 +7,7 @@ spec:
   groups:
   - name: deadmanssnitch-operator
     rules:
-    - alert: Unable to communicate with Dead Man's Snitch
+    - alert: DeadMansSnitchAPIUnavailable
       annotations:
         message: "Unable to communicate with Dead Man's Snitch"
       expr: metricDeadMansSnitchHeartbeat = 0

--- a/deploy/prometheus-k8s-rules.yaml
+++ b/deploy/prometheus-k8s-rules.yaml
@@ -15,4 +15,3 @@ spec:
       for: 15m
       labels:
         severity: critical
-        


### PR DESCRIPTION
In a previous PR, the metric was exposed without a corresponding alert. This PR adds an alert to fire when the API is unreachable for 15 minutes.