### PR TITLE
using operator-custom-metrics library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,8 +47,6 @@
   packages = [
     "pkg/apis/monitoring",
     "pkg/apis/monitoring/v1",
-    "pkg/client/versioned/scheme",
-    "pkg/client/versioned/typed/monitoring/v1",
   ]
   pruneopts = "NT"
   revision = "72ec4b9b16ef11700724dc71fec77112536eed40"
@@ -363,13 +361,20 @@
   revision = "75ba8f5c5122abb2a1da908443c6c9b5e9129479"
 
 [[projects]]
+  digest = "1:341f4eaa5439f00199e5eb36cf068578bf0e63d6f7d6d5307de26ae53d49b784"
+  name = "github.com/openshift/operator-custom-metrics"
+  packages = ["pkg/metrics"]
+  pruneopts = "NT"
+  revision = "d0d7d512f402b1514326f4bf1f6adf17f7097480"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:df8e741cd0f86087367f3bcfeb1cf237e96fada71194b6d4cee9412d221ec763"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
     "pkg/k8sutil",
     "pkg/leader",
     "pkg/log/zap",
-    "pkg/metrics",
     "version",
   ]
   pruneopts = "NT"
@@ -980,13 +985,15 @@
   analyzer-version = 1
   input-imports = [
     "github.com/golang/mock/gomock",
+    "github.com/openshift/api/route/v1",
     "github.com/openshift/hive/pkg/apis",
     "github.com/openshift/hive/pkg/apis/hive/v1alpha1",
     "github.com/openshift/hive/pkg/controller/utils",
+    "github.com/openshift/operator-custom-metrics/pkg/metrics",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/log/zap",
-    "github.com/operator-framework/operator-sdk/pkg/metrics",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/prometheus/client_golang/prometheus",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",

--- a/vendor/github.com/openshift/operator-custom-metrics/LICENSE
+++ b/vendor/github.com/openshift/operator-custom-metrics/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/operator-custom-metrics/example/example.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/example/example.go
@@ -1,0 +1,51 @@
+package example
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/operator-custom-metrics/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
+	log "github.com/sirupsen/logrus"
+)
+
+//Metrics endpoint and path which is to be used to expose metrics.
+const (
+	metricsEndPoint = "8080"
+	metricsPath     = "/metrics"
+)
+
+//Metric variables which are to be collected.
+var (
+	opsProcessed = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "myapp_processed_ops_total",
+		Help: "The total number of processed events Test",
+	})
+)
+
+// RecordMetrics updates the values of the metrics which are to be collected.
+func RecordMetrics() {
+	go func() {
+		for {
+			opsProcessed.Inc()
+			time.Sleep(2 * time.Second)
+		}
+	}()
+}
+
+//TestConfigMetrics creates a metricsConfig object and passes its reference to the library.
+func TestConfigMetrics() {
+
+	prTest := metrics.NewBuilder().
+		WithPort(metricsEndPoint).
+		WithPath(metricsPath).
+		WithCollectors(opsProcessed).
+		WithMetricsFunction(RecordMetrics).
+		GetConfig()
+
+	// Start metrics server with the exposed metrics.
+	if err := metrics.ConfigureMetrics(context.TODO(), *prTest); err != nil {
+		log.Error(err, "Fail")
+	}
+}

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/builder.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/builder.go
@@ -1,0 +1,61 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Default variables for metrics-path and metrics-port.
+const (
+	defaultMetricsPath = "/customMetrics"
+	defaultMetricsPort = "8089"
+)
+
+// metricsConfigBuilder builds a new metricsConfig object.
+type metricsConfigBuilder struct {
+	config metricsConfig
+}
+
+// convertmetrics is a user-defined function, indicating how the metrics are collected.
+type convertMetrics func()
+
+// NewBuilder sets the default values to the metricsConfig object.
+func NewBuilder() *metricsConfigBuilder {
+	return &metricsConfigBuilder{
+		config: metricsConfig{
+			metricsPath:           defaultMetricsPath,
+			metricsPort:           defaultMetricsPort,
+			collectorList:         nil,
+			recordMetricsFunction: nil,
+		},
+	}
+}
+
+// GetConfig returns the reference to the built metricsConfig.
+func (p *metricsConfigBuilder) GetConfig() *metricsConfig {
+	return &p.config
+}
+
+// WithPort updates the metrics port to the value provided by the user.
+func (b *metricsConfigBuilder) WithPort(port string) *metricsConfigBuilder {
+	b.config.metricsPort = port
+	return b
+}
+
+// WithPath updates the metrics path to the value provided by the user.
+func (b *metricsConfigBuilder) WithPath(path string) *metricsConfigBuilder {
+	b.config.metricsPath = path
+	return b
+}
+
+// WithCollectors appends the prometheus-collector provided by the user to a list of Collectors.
+func (b *metricsConfigBuilder) WithCollectors(collector prometheus.Collector) *metricsConfigBuilder {
+	if b.config.collectorList == nil {
+		b.config.collectorList = make([]prometheus.Collector, 0)
+	}
+	b.config.collectorList = append(b.config.collectorList, collector)
+	return b
+}
+
+// WithMetricsFunction updates the configuration with the user-defined function to update the metrics.
+func (b *metricsConfigBuilder) WithMetricsFunction(recordMetricsFunction convertMetrics) *metricsConfigBuilder {
+	b.config.recordMetricsFunction = recordMetricsFunction
+	return b
+}

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metrics.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metrics.go
@@ -1,0 +1,51 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// StartMetrics starts the server based on the metricsConfig provided by the user.
+func StartMetrics(config metricsConfig) {
+	// Register metrics only when the metric list is provided by the operator
+	if config.collectorList != nil {
+		RegisterMetrics(config.collectorList)
+	}
+
+	// Execute recordMetricsFunction if provided by the user
+	if config.recordMetricsFunction != nil {
+		config.recordMetricsFunction()
+	}
+
+	http.Handle(config.metricsPath, prometheus.Handler())
+	log.Info("Port: %v", config.metricsPort)
+	metricsPort := ":" + (config.metricsPort)
+	go http.ListenAndServe(metricsPort, nil)
+}
+
+// RegisterMetrics takes the list of metrics to be registered from the user and
+// registeres to prometheus.
+func RegisterMetrics(list []prometheus.Collector) error {
+	for _, metric := range list {
+		err := prometheus.Register(metric)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metricsconfig.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metricsconfig.go
@@ -1,0 +1,11 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// metricsConfig allows user to specify how to send information to the prometheus instance.
+type metricsConfig struct {
+	metricsPath           string
+	metricsPort           string
+	collectorList         []prometheus.Collector
+	recordMetricsFunction convertMetrics
+}

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/service.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/service.go
@@ -16,10 +16,7 @@ package metrics
 
 import (
 	"context"
-	"errors"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"strconv"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -29,23 +26,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("metrics")
+var (
+	log = logf.Log.WithName("userMetrics")
+)
 
-// Custom errors
-
-// ErrMetricsFailedGenerateService indicates the metric service failed to generate
-var ErrMetricsFailedGenerateService = errors.New("FailedGeneratingService")
-
-// ErrMetricsFailedCreateService indicates that the service failed to create
-var ErrMetricsFailedCreateService = errors.New("FailedCreateService")
-
-// ErrMetricsFailedCreateRoute indicates that the route creation failed
-var ErrMetricsFailedCreateRoute = errors.New("FailedCreateRoute")
-
-// GenerateService returns the static service which exposes specifed port.
+// GenerateService returns the static service at specified port
 func GenerateService(port int32, portName string) (*v1.Service, error) {
 	operatorName, err := k8sutil.GetOperatorName()
 	if err != nil {
@@ -55,6 +45,7 @@ func GenerateService(port int32, portName string) (*v1.Service, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      operatorName,
@@ -80,6 +71,7 @@ func GenerateService(port int32, portName string) (*v1.Service, error) {
 			Selector: map[string]string{"name": operatorName},
 		},
 	}
+
 	return service, nil
 }
 
@@ -90,7 +82,6 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 	for k, v := range s.ObjectMeta.Labels {
 		labels[k] = v
 	}
-
 	return &monitoringv1.ServiceMonitor{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceMonitor",
@@ -114,13 +105,13 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 	}
 }
 
-// GenerateRoute generates an OpenShift route object based on the passed Service object.
-func GenerateRoute(s *v1.Service) *routev1.Route {
+// GenerateRoute creates a route to expose the metrics based on the specified path.
+func GenerateRoute(s *v1.Service, path string) *routev1.Route {
+	log.Info("Staring to generate route modified")
 	labels := make(map[string]string)
 	for k, v := range s.ObjectMeta.Labels {
 		labels[k] = v
 	}
-
 	return &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",
@@ -132,6 +123,7 @@ func GenerateRoute(s *v1.Service) *routev1.Route {
 			Labels:    labels,
 		},
 		Spec: routev1.RouteSpec{
+			Path: path,
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
 				Name: s.ObjectMeta.Name,
@@ -143,24 +135,28 @@ func GenerateRoute(s *v1.Service) *routev1.Route {
 	}
 }
 
-// ConfigureMetrics generates metrics service and route,
-// creates the metrics service and route,
-// and finally it starts the metrics server
-func ConfigureMetrics(ctx context.Context) error {
+// ConfigureMetrics takes the input values from the user, starts the metrics server,
+// as well as crestes service and routes.
+func ConfigureMetrics(ctx context.Context, userMetricsConfig metricsConfig) error {
 	log.Info("Starting prometheus metrics")
-	StartMetrics()
+
+	StartMetrics(userMetricsConfig)
 
 	client, err := createClient()
 	if err != nil {
 		log.Info("Failed to create new client", "Error", err.Error())
-		return nil
+		return err
 	}
 
-	// Generate Service Object
-	s, svcerr := GenerateService(8080, "metrics")
+	p, err := strconv.ParseInt(userMetricsConfig.metricsPort, 10, 32)
+	if err != nil {
+		return err
+	}
+	res := int32(p)
+	s, svcerr := GenerateService(res, "metrics")
 	if svcerr != nil {
 		log.Info("Error generating metrics service object.", "Error", svcerr.Error())
-		return ErrMetricsFailedGenerateService
+		return svcerr
 	}
 	log.Info("Generated metrics service object")
 
@@ -168,35 +164,25 @@ func ConfigureMetrics(ctx context.Context) error {
 	_, err = createOrUpdateService(ctx, client, s)
 	if err != nil {
 		log.Info("Error getting current metrics service", "Error", err.Error())
-		return ErrMetricsFailedCreateService
+		return err
 	}
 
 	log.Info("Created Service")
-
 	// Generate Route Object
-	r := GenerateRoute(s)
+	r := GenerateRoute(s, userMetricsConfig.metricsPath)
 	log.Info("Generated metrics route object")
 
-	// Create or Update the Route
-	err = client.Create(ctx, r)
+	// Create or Update route
+	_, err = createOrUpdateRoute(ctx, client, r)
 	if err != nil {
-		if k8serr.IsAlreadyExists(err) {
-			// update the Route
-			if rUpdateErr := client.Update(ctx, r); rUpdateErr != nil {
-				log.Info("Error creating metrics route", "Error", rUpdateErr.Error())
-				return ErrMetricsFailedCreateRoute
-			}
-			log.Info("Metrics route object updated", "Route.Name", r.Name, "Route.Namespace", r.Namespace)
-			return nil
-		}
-		log.Info("Error creating metrics route", "Error", err.Error())
-		return ErrMetricsFailedCreateRoute
-
+		log.Info("Error creating route", "Error", err.Error())
+		return err
 	}
-	log.Info("Metrics Route object Created", "Route.Name", r.Name, "Route.Namespace", r.Namespace)
 	return nil
 }
 
+// createOrUpdateService creates or Updates a service object
+// which selects the pods from the operator which was deployed.
 func createOrUpdateService(ctx context.Context, client client.Client, s *v1.Service) (*v1.Service, error) {
 	if err := client.Create(ctx, s); err != nil {
 		if !k8serr.IsAlreadyExists(err) {
@@ -216,14 +202,44 @@ func createOrUpdateService(ctx context.Context, client client.Client, s *v1.Serv
 		}
 		err = client.Update(ctx, s)
 		if err != nil {
+			log.Info("Error creating service object", "Error", err)
 			return nil, err
 		}
-		log.Info("Metrics Service object updated", "Service.Name", s.Name, "Service.Namespace", s.Namespace)
+		log.Info("Metrics Service object updated Service.Name %v and Service.Namespace %v", s.Name, s.Namespace)
 		return existingService, nil
 	}
 
-	log.Info("Metrics Service object created", "Service.Name", s.Name, "Service.Namespace", s.Namespace)
+	log.Info("Metrics Service object created Service.Name %v and Service.Namespace %v", s.Name, s.Namespace)
 	return s, nil
+}
+
+//createOrUpdateRoute is a function which creates or updates the route for the service object.
+func createOrUpdateRoute(ctx context.Context, client client.Client, r *routev1.Route) (*routev1.Route, error) {
+	if err := client.Create(ctx, r); err != nil {
+		if err != nil {
+			if !k8serr.IsAlreadyExists(err) {
+				return nil, err
+			}
+
+			existingRoute := &routev1.Route{}
+			err := client.Get(ctx, types.NamespacedName{
+				Name:      r.Name,
+				Namespace: r.Namespace,
+			}, existingRoute)
+			// update the Route
+			r.ResourceVersion = existingRoute.ResourceVersion
+			if err = client.Update(ctx, r); err != nil {
+				log.Info("Error creating metrics route", "Error", err.Error())
+				return nil, err
+			}
+			log.Info("Metrics Route object updated Route.Name %v and Route.Namespace %v", r.Name, r.Namespace)
+			return existingRoute, nil
+		}
+
+	}
+	log.Info("Metrics Route object Created", "Route.Name", r.Name, "Route.Namespace", r.Namespace)
+	return r, nil
+
 }
 
 func createClient() (client.Client, error) {


### PR DESCRIPTION
Replaces pkg/metrics/service.go with using github.com/openshift/operator-custom-metrics pkg to register and expose metrics.