### PR TITLE
Update to operator-custom-metrics v0.2.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -349,12 +349,12 @@
   revision = "7776e82850f8803419ecd92d13c7e09c6cc2cc41"
 
 [[projects]]
-  digest = "1:341f4eaa5439f00199e5eb36cf068578bf0e63d6f7d6d5307de26ae53d49b784"
+  digest = "1:c67dd573eb0c047dc1036884e264e69dd44b9b07bab1482ea1cd7cb760e91599"
   name = "github.com/openshift/operator-custom-metrics"
   packages = ["pkg/metrics"]
   pruneopts = "NT"
-  revision = "d0d7d512f402b1514326f4bf1f6adf17f7097480"
-  version = "v0.1.0"
+  revision = "6a7c3bd8b210d68dac10a3130c19f64d40eb8556"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:df8e741cd0f86087367f3bcfeb1cf237e96fada71194b6d4cee9412d221ec763"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,6 +56,10 @@ required = [
   name = "sigs.k8s.io/controller-runtime"
   version = "=v0.1.10"
 
+[[override]]
+  name = "github.com/openshift/operator-custom-metrics"
+  version = "=v0.2.1"
+
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -123,11 +123,14 @@ func main() {
 	}
 
 	metricsServer := metrics.NewBuilder().WithPort(metricsPort).WithPath(metricsPath).
-		WithCollectors(localmetrics.MetricDeadMansSnitchHeartbeat).
+		WithCollectors(localmetrics.MetricsList).
+		WithRoute().
 		GetConfig()
+
 	// Configure metrics if it errors log the error but continue
 	if err := metrics.ConfigureMetrics(context.TODO(), *metricsServer); err != nil {
 		log.Error(err, "Failed to configure Metrics")
+		os.Exit(1)
 	}
 
 	log.Info("Starting the Cmd.")

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/builder.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/builder.go
@@ -6,6 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 const (
 	defaultMetricsPath = "/customMetrics"
 	defaultMetricsPort = "8089"
+	defaultServiceName = "operator-metrics"
 )
 
 // metricsConfigBuilder builds a new metricsConfig object.
@@ -13,17 +14,14 @@ type metricsConfigBuilder struct {
 	config metricsConfig
 }
 
-// convertmetrics is a user-defined function, indicating how the metrics are collected.
-type convertMetrics func()
-
 // NewBuilder sets the default values to the metricsConfig object.
 func NewBuilder() *metricsConfigBuilder {
 	return &metricsConfigBuilder{
 		config: metricsConfig{
-			metricsPath:           defaultMetricsPath,
-			metricsPort:           defaultMetricsPort,
-			collectorList:         nil,
-			recordMetricsFunction: nil,
+			metricsPath:   defaultMetricsPath,
+			metricsPort:   defaultMetricsPort,
+			serviceName:   defaultServiceName,
+			collectorList: nil,
 		},
 	}
 }
@@ -45,8 +43,14 @@ func (b *metricsConfigBuilder) WithPath(path string) *metricsConfigBuilder {
 	return b
 }
 
-// WithCollectors appends the prometheus-collector provided by the user to a list of Collectors.
-func (b *metricsConfigBuilder) WithCollectors(collector prometheus.Collector) *metricsConfigBuilder {
+//WithName specifies the name of the service
+func (b *metricsConfigBuilder) WithServiceName(name string) *metricsConfigBuilder {
+	b.config.serviceName = name
+	return b
+}
+
+// WithCollector appends the prometheus-collector provided by the user to a list of Collectors.
+func (b *metricsConfigBuilder) WithCollector(collector prometheus.Collector) *metricsConfigBuilder {
 	if b.config.collectorList == nil {
 		b.config.collectorList = make([]prometheus.Collector, 0)
 	}
@@ -54,8 +58,18 @@ func (b *metricsConfigBuilder) WithCollectors(collector prometheus.Collector) *m
 	return b
 }
 
-// WithMetricsFunction updates the configuration with the user-defined function to update the metrics.
-func (b *metricsConfigBuilder) WithMetricsFunction(recordMetricsFunction convertMetrics) *metricsConfigBuilder {
-	b.config.recordMetricsFunction = recordMetricsFunction
+// WithCollectors updates the collectorList to the list of collectors provided by the user.
+func (b *metricsConfigBuilder) WithCollectors(collectors []prometheus.Collector) *metricsConfigBuilder {
+	b.config.collectorList = collectors
+	return b
+}
+
+func (b *metricsConfigBuilder) WithRoute() *metricsConfigBuilder {
+	b.config.withRoute = true
+	return b
+}
+
+func (b *metricsConfigBuilder) WithServiceMonitor() *metricsConfigBuilder {
+	b.config.withServiceMonitor = true
 	return b
 }

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metrics.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metrics.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,13 +28,8 @@ func StartMetrics(config metricsConfig) {
 		RegisterMetrics(config.collectorList)
 	}
 
-	// Execute recordMetricsFunction if provided by the user
-	if config.recordMetricsFunction != nil {
-		config.recordMetricsFunction()
-	}
-
 	http.Handle(config.metricsPath, prometheus.Handler())
-	log.Info("Port: %v", config.metricsPort)
+	log.Info(fmt.Sprintf("Port: %s", config.metricsPort))
 	metricsPort := ":" + (config.metricsPort)
 	go http.ListenAndServe(metricsPort, nil)
 }

--- a/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metricsconfig.go
+++ b/vendor/github.com/openshift/operator-custom-metrics/pkg/metrics/metricsconfig.go
@@ -4,8 +4,10 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // metricsConfig allows user to specify how to send information to the prometheus instance.
 type metricsConfig struct {
-	metricsPath           string
-	metricsPort           string
-	collectorList         []prometheus.Collector
-	recordMetricsFunction convertMetrics
+	metricsPath        string
+	metricsPort        string
+	serviceName        string
+	collectorList      []prometheus.Collector
+	withRoute          bool
+	withServiceMonitor bool
 }


### PR DESCRIPTION
Simplify metrics setup by upgrading to v0.2.1 of the operator custom metrics library. This change makes the operator exit on startup if the metrics stack does not come up correctly.