### PR TITLE
use pre-created secret instead of embed in syncset

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	OperatorName      string = "deadmanssnitch-operator"
 	OperatorNamespace string = "deadmanssnitch-operator"
 	SyncSetPostfix    string = "-dms"
+	RefSecretPostfix  string = "-dms-secret"
 	KeySnitchURL      string = "SNITCH_URL"
 
 	// ClusterDeploymentManagedLabel is the label the clusterdeployment will have that determines


### PR DESCRIPTION
As requested in https://jira.coreos.com/browse/SREP-1831
And discussed with @wanghaoran1988 , he suggested that we should do the clean up things manually on the running clusters.