### PR TITLE
add resource limits/requests for the operator per OSD-2109

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,13 @@ spec:
           command:
           - deadmanssnitch-operator
           imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "20m"
+            limits:
+              memory: "400Mi"
+              cpu: "50m"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Checked on the current hive stage and hive prod,
The limits and requests should be safe.

STG:
deadmanssnitch-operator                        deadmanssnitch-operator-7c8fb99968-hlflc         3m           202Mi

PROD:
deadmanssnitch-operator                           deadmanssnitch-operator-7975fcf794-h8t49           3m           110Mi
