### PR TITLE
Add support for new 'ext' noalerts label.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,5 +25,7 @@ const (
 	// if the cluster is OSD (managed) or not
 	ClusterDeploymentManagedLabel string = "api.openshift.com/managed"
 	// ClusterDeploymentNoalertsLabel is the label the clusterdeployment will have if the cluster should not send alerts
-	ClusterDeploymentNoalertsLabel string = "api.openshift.com/noalerts"
+	ClusterDeploymentNoalertsLabel string = "ext-managed.openshift.io/noalerts"
+	// ClusterDeploymentNoalertsLabelOld is the OLD label used and will be remoed as a part of https://issues.redhat.com/browse/OSD-4059
+	ClusterDeploymentNoalertsLabelOld string = "api.openshift.com/noalerts"
 )

--- a/pkg/controller/deadmanssnitch/deadmanssnitch_controller_test.go
+++ b/pkg/controller/deadmanssnitch/deadmanssnitch_controller_test.go
@@ -207,6 +207,26 @@ func noalertsManagedClusterDeployment() *hivev1.ClusterDeployment {
 	return &cd
 }
 
+func noalertsManagedClusterDeploymentOld() *hivev1.ClusterDeployment {
+	labelMap := map[string]string{
+		config.ClusterDeploymentManagedLabel:     "true",
+		config.ClusterDeploymentNoalertsLabelOld: "true",
+	}
+	cd := hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testClusterName,
+			Namespace: testNamespace,
+			Labels:    labelMap,
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: testClusterName,
+		},
+	}
+	cd.Spec.Installed = true
+
+	return &cd
+}
+
 func TestReconcileClusterDeployment(t *testing.T) {
 	hiveapis.AddToScheme(scheme.Scheme)
 	tests := []struct {
@@ -293,6 +313,18 @@ func TestReconcileClusterDeployment(t *testing.T) {
 			name: "Test Create Managed ClusterDeployment with Alerts disabled",
 			localObjects: []runtime.Object{
 				noalertsManagedClusterDeployment(),
+			},
+			expectedSyncSets: &SyncSetEntry{},
+			expectedSecret:   &SecretEntry{},
+			verifySyncSets:   verifyNoSyncSet,
+			verifySecret:     verifyNoSecret,
+			setupDMSMock: func(r *mockdms.MockClientMockRecorder) {
+			},
+		},
+		{
+			name: "Test Create Managed ClusterDeployment with Alerts disabled (OLD)",
+			localObjects: []runtime.Object{
+				noalertsManagedClusterDeploymentOld(),
 			},
 			expectedSyncSets: &SyncSetEntry{},
 			expectedSecret:   &SecretEntry{},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -89,6 +89,14 @@ func CheckClusterDeployment(request reconcile.Request, client client.Client, req
 		}
 	}
 
+	// the old way, goes away with https://issues.redhat.com/browse/OSD-4059
+	if val, ok := clusterDeployment.GetLabels()[config.ClusterDeploymentNoalertsLabelOld]; ok {
+		if val == "true" {
+			reqLogger.Info("Managed cluster with Alerts disabled", "Namespace", request.Namespace, "Name", request.Name)
+			return false, clusterDeployment, nil
+		}
+	}
+
 	// made it this far so it's both managed and has alerts enabled
 	return true, clusterDeployment, nil
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4059

A future phase will remove the old label.  Tracked as a task in the above story.