### PR TITLE
Aesthetic cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/cluster-network-operator v0.0.0-20190207145423-c226dcab667e // indirect
 	github.com/openshift/hive v0.0.0-20200210203046-8b1c393442db
-	github.com/openshift/operator-custom-metrics v0.3.0 // indirect
+	github.com/openshift/operator-custom-metrics v0.3.0
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/pkg/dmsclient/dmsclient.go
+++ b/pkg/dmsclient/dmsclient.go
@@ -110,7 +110,7 @@ func (c *dmsClient) newRequest(method, path string, body interface{}) (*http.Req
 func (c *dmsClient) do(req *http.Request, operation string) (*http.Response, error) {
 	start := time.Now()
 	defer func() {
-		c.metricsCollector.RecordSnitchCallDuration(time.Since(start), operation)
+		c.metricsCollector.ObserveSnitchCallDuration(time.Since(start).Seconds(), operation)
 	}()
 	resp, err := c.httpClient.Do(req)
 
@@ -120,7 +120,7 @@ func (c *dmsClient) do(req *http.Request, operation string) (*http.Response, err
 	}
 
 	if err != nil {
-		c.metricsCollector.RecordSnitchCallError()
+		c.metricsCollector.ObserveSnitchCallError()
 		return resp, fmt.Errorf("Error calling the API endpoint: %v", err)
 	}
 

--- a/pkg/utils/clientwrapper.go
+++ b/pkg/utils/clientwrapper.go
@@ -77,7 +77,7 @@ func (cmt *ControllerMetricsTripper) RoundTrip(req *http.Request) (*http.Respons
 
 	// Count this call, if it worked (where "worked" includes HTTP errors).
 	if err == nil {
-		localmetrics.Collector.AddAPICall(cmt.Controller, req, resp, time.Since(start).Seconds())
+		localmetrics.Collector.ObserveAPICall(cmt.Controller, req, resp, time.Since(start).Seconds())
 	}
 
 	return resp, err


### PR DESCRIPTION
Following on from [closing comments](https://github.com/openshift/deadmanssnitch-operator/pull/67#pullrequestreview-456669366) on #67:
- Remove unused `MetricsCollector.collectors`.
- Make metrics observers consistent in naming (`Observe*`) and how they accept the duration parameter (`duration float64`).
- Corrects comments about double-counting errors.