### PR TITLE
Disable the controller runtime metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -91,7 +91,7 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          "",
+		Namespace: "",
 		// disable the controller-runtime metrics
 		MetricsBindAddress: "0",
 	})

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -91,7 +91,9 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace: "",
+		Namespace:          "",
+		// disable the controller-runtime metrics
+		MetricsBindAddress: "0",
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/cluster-network-operator v0.0.0-20190207145423-c226dcab667e // indirect
 	github.com/openshift/hive v0.0.0-20200210203046-8b1c393442db
-	github.com/openshift/operator-custom-metrics v0.3.0 // indirect
+	github.com/openshift/operator-custom-metrics v0.3.0
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
The `operator-sdk` was updated in a separate PR #65 which broke the metrics which were introduced in #67 due a conflict between the metrics served by the `controller-runtime` and `operator-custom-metrics`. Since we don't use the runtime metrics I have just disabled them.

Also `go mod tidy`

/assign @jewzaam @jharrington22 
/cc @2uasimojo 