### PR TITLE
Clean up all DMS snitches when cluster is deleting

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,12 +21,8 @@ var log = logf.Log.WithName("")
 
 // HasFinalizer returns true if the given object has the given finalizer
 func HasFinalizer(object metav1.Object, finalizer string) bool {
-	for _, f := range object.GetFinalizers() {
-		if f == finalizer {
-			return true
-		}
-	}
-	return false
+	finalizers := sets.NewString(object.GetFinalizers()...)
+	return finalizers.Has(finalizer)
 }
 
 // AddFinalizer adds a finalizer to the given object


### PR DESCRIPTION
When a ClusterDeployment is deleting, no matter what the label set, if the finalizer matches an active DMSI, remove the finalizer and clean up.

fixes [OSD-5477](https://issues.redhat.com/browse/OSD-5477)