### PR TITLE
Move CRD fixup hack for 3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,14 @@ include boilerplate/generated-includes.mk
 boilerplate-update:
 	@boilerplate/update
 
+# ==> HACK ==>
+# We have to tweak the YAML to run this on 3.11.
+# We'll add a target to do that, then override the `generate` target to
+# call it.
+.PHONY: crd-fixup
+crd-fixup:
+	yq d -i deploy/crds/deadmanssnitch.managed.openshift.io_deadmanssnitchintegrations_crd.yaml spec.validation.openAPIV3Schema.type
+
+# NOTE: go-generate is a no-op at the moment.
+generate: op-generate crd-fixup go-generate
+# <== HACK <==

--- a/deploy/crds/deadmanssnitch.managed.openshift.io_deadmanssnitchintegrations_crd.yaml
+++ b/deploy/crds/deadmanssnitch.managed.openshift.io_deadmanssnitchintegrations_crd.yaml
@@ -9,124 +9,96 @@ spec:
     listKind: DeadmansSnitchIntegrationList
     plural: deadmanssnitchintegrations
     shortNames:
-    - dmsi
+      - dmsi
     singular: deadmanssnitchintegration
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      description: DeadmansSnitchIntegration is the Schema for the deadmanssnitchintegrations
-        API
+      description: DeadmansSnitchIntegration is the Schema for the deadmanssnitchintegrations API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: DeadmansSnitchIntegrationSpec defines the desired state of
-            DeadmansSnitchIntegration
+          description: DeadmansSnitchIntegrationSpec defines the desired state of DeadmansSnitchIntegration
           properties:
             clusterDeploymentSelector:
-              description: a label selector used to find which clusterdeployment CRs
-                receive a DMS integration based on this configuration
+              description: a label selector used to find which clusterdeployment CRs receive a DMS integration based on this configuration
               properties:
                 matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                   items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                     properties:
                       key:
-                        description: key is the label key that the selector applies
-                          to.
+                        description: key is the label key that the selector applies to.
                         type: string
                       operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
+                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                         type: string
                       values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
+                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
                   additionalProperties:
                     type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                   type: object
               type: object
             dmsAPIKeySecretRef:
               description: reference to the secret containing deadmanssnitch-api-key
               properties:
                 name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
+                  description: Name is unique within a namespace to reference a secret resource.
                   type: string
                 namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
+                  description: Namespace defines the space within which the secret name must be unique.
                   type: string
               type: object
             snitchNamePostFix:
-              description: The postfix to append to any snitches managed by this integration.  I.e.
-                "osd" or "rhmi"
+              description: The postfix to append to any snitches managed by this integration.  I.e. "osd" or "rhmi"
               type: string
             tags:
-              description: Array of strings that are applied to the service created
-                in DMS
+              description: Array of strings that are applied to the service created in DMS
               items:
                 type: string
               type: array
             targetSecretRef:
-              description: name and namespace in the target cluster where the secret
-                is synced
+              description: name and namespace in the target cluster where the secret is synced
               properties:
                 name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
+                  description: Name is unique within a namespace to reference a secret resource.
                   type: string
                 namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
+                  description: Namespace defines the space within which the secret name must be unique.
                   type: string
               type: object
           required:
-          - clusterDeploymentSelector
-          - dmsAPIKeySecretRef
-          - targetSecretRef
+            - clusterDeploymentSelector
+            - dmsAPIKeySecretRef
+            - targetSecretRef
           type: object
         status:
-          description: DeadmansSnitchIntegrationStatus defines the observed state
-            of DeadmansSnitchIntegration
+          description: DeadmansSnitchIntegrationStatus defines the observed state of DeadmansSnitchIntegration
           type: object
       required:
-      - spec
+        - spec
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/hack/crd_fixup.sh
+++ b/hack/crd_fixup.sh
@@ -3,9 +3,6 @@
 # Commands need to be run from project root
 cd "$( dirname "${BASH_SOURCE[0]}" )"/..
 
-operator-sdk generate k8s
-operator-sdk generate crds
-
 # This can be removed once the operator no longer needs to be run on
 # OpenShift v3.11
 yq d -i deploy/crds/deadmanssnitch.managed.openshift.io_deadmanssnitchintegrations_crd.yaml \

--- a/pkg/apis/deadmanssnitch/v1alpha1/deadmanssnitchintegration_types.go
+++ b/pkg/apis/deadmanssnitch/v1alpha1/deadmanssnitchintegration_types.go
@@ -46,7 +46,6 @@ type DeadmansSnitchIntegration struct {
 	Status DeadmansSnitchIntegrationStatus `json:"status,omitempty"`
 }
 
-//go:generate ../../../../hack/generate.sh
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DeadmansSnitchIntegrationList contains a list of DeadmansSnitchIntegration


### PR DESCRIPTION
Due to an OLM bug in OCP 3.11, the generated CRD needs some tweaking. Previously this was being done via a bespoke script invoked through a go:generate directive. After boilerplate adoption, this script was doing `operator-sdk generate` redundantly (it was already part of the `op-generate` target).

This commit removes the script and the redundant `operator-sdk generate`s, and adds a temporary `make` target to do the CRD fixup. All of this will go away once we no longer need to run on 3.11.