### PR TITLE
Use ubi-minimal for second stage operator image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/deadmanssnitch-operator
 ENV GOFLAGS=""
 RUN make go-build
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV OPERATOR_BIN=deadmanssnitch-operator
 
 WORKDIR /root/


### PR DESCRIPTION
The operator binary doesn't need to run in the origin image. Use ubi-minimal to cut down on the deploy image size.