### PR TITLE
OSD-6070 Patch clusterdeployment instead of update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,133 @@ data:
 
 - Build a docker image and replace `REPLACE_IMAGE` [operator.yaml](deploy/operator.yaml) field with that image
 - Deploy using `oc apply -f deploy/`
+
+## Development
+
+### Set up local OpenShift cluster
+
+Methods include:
+- [MiniShift](https://github.com/minishift/minishift)
+- [Code Ready Containers](https://developers.redhat.com/products/codeready-containers/overview)
+- [Integration OpenShift Cluster Manager](https://qaprodauth.cloud.redhat.com/openshift/?env=integration)
+
+### Deploy dependencies
+
+[Hive](https://github.com/openshift/hive/) CRDs need to be installed on the cluster.
+
+Clone [hive repo](https://github.com/openshift/hive/) and run
+
+```terminal
+$ git clone https://github.com/openshift/hive.git
+$ oc apply -f hive/config/crds
+```
+
+Install the `DeadMansSnitchIntegration` CRD, create the operator namespace and other operator dependencies:
+
+```terminal
+$ oc apply -f deploy/crds/deadmanssnitch.managed.openshift.io_deadmanssnitchintegrations_crd.yaml
+$ oc new-project deadmanssnitch-operator
+$ oc apply -f deploy/role.yaml
+$ oc apply -f deploy/service_account.yaml
+$ oc apply -f deploy/role_binding.yaml
+$ oc apply -f deploy/prometheus-k8s-role.yaml
+$ oc apply -f deploy/prometheus-k8s-rules.yaml
+$ oc apply -f deploy/prometheus-k8s-rolebinding.yaml
+```
+
+Create a secret which will contain the DeadMansSnitch API Key and Hive Cluster Tag. 
+
+You will require an API Key signed up to a DeadMansSnitch plan that allows for enhanced snitch intervals (the "Private Eye" plan). You can alternatively test the `deadmanssnitch-oeprator` by signing up to the free tier DeadMansSnitch plan (limited to 1 snitch), but doing so will require you to customize the snitch interval from `15_minute` to `hourly`. This can be performed in [deadmanssnitchintegration_controller.go](pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go) 
+
+Adjust the example below and apply the file with `oc apply -f <file>`. Note that the values for `hive-cluster-tag` and `deadmanssnitch-api-key` need to be base64 encoded. This can be performed using `echo -n <text> | base64`.
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: deadmanssnitch-api-key
+  namespace: deadmanssnitch-operator
+data:
+  hive-cluster-tag: <value>
+  deadmanssnitch-api-key: <value>
+```
+
+### Define a DeadMansSnitchIntegration
+
+Create a `DeadMansSnitchIntegration` CR which will be used to identify clusters to apply DMS to.
+
+The example below will target `clusterdeployment`s that have a `api.openshift.com/test` label set to `"true"`. Apply it using `oc apply -f <file>`.
+
+```yaml
+apiVersion: deadmanssnitch.managed.openshift.io/v1alpha1
+kind: DeadmansSnitchIntegration
+metadata:
+  finalizers:
+  - dms.managed.openshift.io/deadmanssnitch-osd
+  name: test-dmsi
+  namespace: deadmanssnitch-operator
+spec:
+  clusterDeploymentSelector:
+    matchExpressions:
+    - key: api.openshift.com/test
+      operator: In
+      values:
+      - "true"
+  dmsAPIKeySecretRef:
+    name: deadmanssnitch-api-key
+    namespace: deadmanssnitch-operator
+  snitchNamePostFix: ""
+  tags:
+  - test
+  targetSecretRef:
+    name: dms-secret
+    namespace: openshift-monitoring
+```
+
+### Run the operator
+
+```terminal
+$ export OPERATOR_NAME=deadmanssnitch-operator
+$ go run cmd/manager/main.go
+```
+
+### Create Clusterdeployment
+
+You can create a dummy ClusterDeployment by copying a real one from an active hive
+
+```terminal
+real-hive$ oc get cd -n <namespace> <cdname> -o yaml > /tmp/fake-clusterdeployment.yaml
+
+...
+
+$ oc create namespace fake-cluster-namespace
+$ oc apply -f /tmp/fake-clusterdeployment.yaml
+```
+
+`deadmanssnitch-operator` doesn't start reconciling clusters until the `clusterdeployment`'s `spec.installed` is set to `true`. If present, set `spec.installed` to true.
+
+```terminal
+$ oc edit clusterdeployment fake-cluster -n fake-cluster-namespace
+```
+
+Ensure that the ClusterDeployment is labelled with the label from your `DMSI`'s `clusterDeploymentSelector` clause. 
+
+Using the example from earlier:
+```terminal
+$ oc label clusterdeployment -n <namespace> <cdname> api.openshift.com/test=true 
+```
+
+### Delete ClusterDeployment
+
+To trigger `deadmanssnitch-operator` to remove the service in DeadMansSnitch, you can either delete the `clusterdeployment` or remove the `clusterDeploymentSelector` label:
+
+```terminal
+$ oc delete clusterdeployment fake-cluster -n fake-cluster-namespace
+```
+
+If deleting the `clsuterdeployment`, you may need to remove dangling finalizers from the `clusterdeployment` object.
+
+```terminal
+$ oc edit clusterdeployment fake-cluster -n fake-cluster-namespace
+```

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ spec:
   dmsAPIKeySecretRef:
     name: deadmanssnitch-api-key
     namespace: deadmanssnitch-operator
-  snitchNamePostFix: ""
+  snitchNamePostFix: "test"
   tags:
   - test
   targetSecretRef:
-    name: dms-secret
+    name: dms-secret-test
     namespace: openshift-monitoring
 ```
 

--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -288,7 +288,7 @@ func (r *ReconcileDeadmansSnitchIntegration) dmsAddFinalizer(dmsi *deadmanssnitc
 
 // create snitch in deadmanssnitch.com with information retrived from dmsi cr as well as the matching cluster deployment
 func (r *ReconcileDeadmansSnitchIntegration) createSnitch(dmsi *deadmanssnitchv1alpha1.DeadmansSnitchIntegration, cd *hivev1.ClusterDeployment, dmsc dmsclient.Client) error {
-	logger := log.WithValues("DeadMansSnitchIntegration.Namespace", dmsi.Namespace, "DMSI.Name", dmsi.Name, "cd.Name", cd.Name, "cluster-deployment.Namespace:", cd.Namespace)
+	logger := log.WithValues("DeadMansSnitchIntegration.Namespace", dmsi.Namespace, "DMSI.Name", dmsi.Name, "cluster-deployment.Name:", cd.Name, "cluster-deployment.Namespace:", cd.Namespace)
 	snitchName := utils.DmsSnitchName(cd.Spec.ClusterName, cd.Spec.BaseDomain, dmsi.Spec.SnitchNamePostFix)
 
 	ssName := utils.SecretName(cd.Spec.ClusterName, dmsi.Spec.SnitchNamePostFix)
@@ -340,7 +340,7 @@ func (r *ReconcileDeadmansSnitchIntegration) createSnitch(dmsi *deadmanssnitchv1
 
 //Create secret containing the snitch url
 func (r *ReconcileDeadmansSnitchIntegration) createSecret(dmsi *deadmanssnitchv1alpha1.DeadmansSnitchIntegration, dmsc dmsclient.Client, cd hivev1.ClusterDeployment) error {
-	logger := log.WithValues("DeadMansSnitchIntegration.Namespace", dmsi.Namespace, "DMSI.Name", dmsi.Name, "cd.Name:", cd.Name, "cluster-deployment.Namespace:", cd.Namespace)
+	logger := log.WithValues("DeadMansSnitchIntegration.Namespace", dmsi.Namespace, "DMSI.Name", dmsi.Name, "cluster-deployment.Name:", cd.Name, "cluster-deployment.Namespace:", cd.Namespace)
 	dmsSecret := utils.SecretName(cd.Spec.ClusterName, dmsi.Spec.SnitchNamePostFix)
 	logger.Info("Checking if secret already exits")
 	err := r.client.Get(context.TODO(),


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
This PR changes the logic of the `deadmanssnitch-operator` to perform a `Patch()` of the `clusterdeployment` CR when adding or removing finalizers, rather than an `Update()`, in order to eliminate the possibility that the `Update()` call will drop data from the CR.

This PR also updates the `README` documentation to include "getting started" steps for local development, based on the very similar `pagerduty-operator`.

Some minor other nits are also addressed (spelling errors, and bad usage of `logger.Info()`)

### Which Jira/Github issue(s) this PR fixes?
[OSD-6070](https://issues.redhat.com/browse/OSD-6070)

### Special notes for your reviewer:
I've tested this with a local deployment of `deadmanssnitch-operator` and verified that finalizers are still created and removed as expected. I have also verified that - if the Hive `clusterdeployment` CRD introduces a new field and sets that value in a `clusterdeployment` CR - the currently running operator does not remove that new field when it performs the `Patch()`, as per the goals of [OSD-6070](https://issues.redhat.com/browse/OSD-6070).

Related PRs:
- [pagerduty-operator](https://github.com/openshift/pagerduty-operator/pull/137)
- [certman-operator](https://github.com/openshift/certman-operator/pull/175)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
