### PR TITLE
Use IMAGE_DIGEST in OLM template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -8,10 +8,8 @@ parameters:
   required: true
 - name: CHANNEL
   value: staging
-- name: IMAGE_TAG
-  value: latest
-- name: REPO_DIGEST
-  value: latest
+- name: IMAGE_DIGEST
+  required: true
 - name: SILENT_ALERT_LEGALENTITY_IDS
   value: '["None"]'
 - name: DEADMANSSNITCH_OSD_TAGS
@@ -24,7 +22,7 @@ objects:
     name: deadmanssnitch-operator-catalog
   spec:
     sourceType: grpc
-    image: ${REPO_DIGEST}
+    image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
     displayName: deadmanssnitch-operator Registry
     publisher: SRE 
 


### PR DESCRIPTION
To make the OLM template easier to understand, replace `${REPO_DIGEST}` with `${REGISTRY_IMG}@${IMAGE_DIGEST}`.

`IMAGE_DIGEST` is supported as of APPSRE-3265.