### PR TITLE
OSD-7196 Disable DMS for "fake" OSD clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -84,3 +84,5 @@ objects:
     clusterDeploymentAnnotationsToSkip:
     - name: hive.openshift.io/fake-cluster
       value: "true"
+    - name: managed.openshift.com/fake
+      value: "true"

--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
@@ -47,6 +47,7 @@ const (
 	deadMansSnitchOperatorNamespace   = "deadmanssnitch-operator"
 	deadMansSnitchAPISecretName       = "deadmanssnitch-api-key"
 	testFakeClusterKey                = "hive.openshift.io/fake-cluster"
+	testOtherFakeClusterKey           = "managed.openshift.com/fake"
 	testExternalID                    = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 )
 
@@ -131,6 +132,14 @@ func testFakeClusterDeployment() *hivev1.ClusterDeployment {
 	return cd
 }
 
+func testOtherFakeClusterDeployment() *hivev1.ClusterDeployment {
+	cd := testClusterDeployment()
+
+	cd.Annotations[testOtherFakeClusterKey] = "true"
+
+	return cd
+}
+
 func testDeadMansSnitchIntegration() *deadmanssnitchv1alpha1.DeadmansSnitchIntegration {
 
 	return &deadmanssnitchv1alpha1.DeadmansSnitchIntegration{
@@ -182,6 +191,10 @@ func testDeadMansSnitchIntegrationWithSkips() *deadmanssnitchv1alpha1.DeadmansSn
 					Name:  testFakeClusterKey,
 					Value: "true",
 				},
+				{
+					Name:  testOtherFakeClusterKey,
+					Value: "true",
+				},
 			},
 		},
 	}
@@ -225,6 +238,15 @@ func uninstalledClusterDeployment() *hivev1.ClusterDeployment {
 	cd := testClusterDeployment()
 	cd.Spec.Installed = false
 	cd.ObjectMeta.Finalizers = nil // operator will not have set a finalizer if it was never installed
+
+	return cd
+}
+
+// return a fake ClusterDeployment
+func fakeClusterDeployment() *hivev1.ClusterDeployment {
+	cd := testClusterDeployment()
+
+	cd.ObjectMeta.Finalizers = nil // won't have a finalizer if it is fake
 
 	return cd
 }
@@ -442,6 +464,25 @@ func TestReconcileClusterDeployment(t *testing.T) {
 				testSecret(),
 				testDeadMansSnitchIntegrationWithSkips(),
 				testFakeClusterDeployment(),
+			},
+			expectedSyncSets: &SyncSetEntry{},
+			expectedSecret:   &SecretEntry{},
+			verifySyncSets:   verifyNoSyncSet,
+			verifySecret:     verifyNoSecret,
+			setupDMSMock: func(r *mockdms.MockClientMockRecorder) {
+				r.Create(gomock.Any()).Times(0)
+				r.FindSnitchesByName(gomock.Any()).Return([]dmsclient.Snitch{}, nil).Times(1)
+				r.Delete(gomock.Any()).Times(0)
+				r.Update(gomock.Any()).Times(0)
+				r.CheckIn(gomock.Any()).Times(0)
+			},
+		},
+		{
+			name: "Test Skip with Other Fake cluster",
+			localObjects: []runtime.Object{
+				testSecret(),
+				testDeadMansSnitchIntegrationWithSkips(),
+				testOtherFakeClusterDeployment(),
 			},
 			expectedSyncSets: &SyncSetEntry{},
 			expectedSecret:   &SecretEntry{},

--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
@@ -242,15 +242,6 @@ func uninstalledClusterDeployment() *hivev1.ClusterDeployment {
 	return cd
 }
 
-// return a fake ClusterDeployment
-func fakeClusterDeployment() *hivev1.ClusterDeployment {
-	cd := testClusterDeployment()
-
-	cd.ObjectMeta.Finalizers = nil // won't have a finalizer if it is fake
-
-	return cd
-}
-
 // return a ClusterDeployment with Label["managed"] == false
 func nonManagedClusterDeployment() *hivev1.ClusterDeployment {
 	cd := testClusterDeployment()


### PR DESCRIPTION
Adds additional "managed.openshift.com/fake" annotation to skip.

Fixes logic when there are multiple annotations to skip.