### PR TITLE
OSD-9238 Added var for Fedramp

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -36,3 +36,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "deadmanssnitch-operator"
+            - name: FEDRAMP
+              value: "false"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -16,6 +16,8 @@ parameters:
   value: '["None"]'
 - name: DEADMANSSNITCH_OSD_TAGS
   required: true
+- name: FEDRAMP
+  value: "false"
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -45,6 +47,10 @@ objects:
     name: deadmanssnitch-operator
     source: deadmanssnitch-operator-catalog
     sourceNamespace: deadmanssnitch-operator
+  config:
+    env:
+    - name: FEDRAMP
+      value: "${FEDRAMP}"
 
 - apiVersion: deadmanssnitch.managed.openshift.io/v1alpha1
   kind: DeadmansSnitchIntegration

--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -3,6 +3,7 @@ package deadmanssnitchintegration
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/openshift/deadmanssnitch-operator/config"
 	deadmanssnitchv1alpha1 "github.com/openshift/deadmanssnitch-operator/pkg/apis/deadmanssnitch/v1alpha1"
@@ -28,6 +29,8 @@ import (
 )
 
 var log = logf.Log.WithName("controller_deadmanssnitchintegration")
+
+var fedramp = os.Getenv("FEDRAMP") == "true"
 
 const (
 	deadMansSnitchAPISecretKey    = "deadmanssnitch-api-key"
@@ -123,6 +126,13 @@ type ReconcileDeadmansSnitchIntegration struct {
 func (r *ReconcileDeadmansSnitchIntegration) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling DeadmansSnitchIntegration")
+
+	if len(os.Getenv("FEDRAMP")) == 0 {
+		reqLogger.Info("FEDRAMP environment variable unset, defaulting to false")
+	} else {
+		reqLogger.Info("running in FedRAMP environment: %b", fedramp)
+	}
+
 	// Fetch the DeadmansSnitchIntegration dmsi
 	dmsi := &deadmanssnitchv1alpha1.DeadmansSnitchIntegration{}
 


### PR DESCRIPTION
This PR adds a deployment parameter to the OLM template so that AppSRE can deploy the operator in different govcloud vs. non-govcloud environments.