### PR TITLE
Attempt to verify PowerState before checking legacy conditions

### DIFF
--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -40,13 +40,6 @@ const (
 	legacyHivev1RunningHibernationReason = "Running"
 )
 
-var validHibernationReasons = []string{
-	hivev1.ResumingOrRunningHibernationReason,
-	// This can be removed once Hive is promoted past f73ed3e in all environments
-	// Support for this condition was removed in https://github.com/openshift/hive/pull/1604
-	legacyHivev1RunningHibernationReason,
-}
-
 // Add creates a new DeadmansSnitchIntegration Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -619,7 +612,7 @@ func instancesAreRunning(cd hivev1.ClusterDeployment) bool {
 	// ie. The cluster is not "Resuming" if the PowerState is "Running", the cluster is operational.
 	// If the field is blank we move on and check the legacy reasons (It may be blank if the running version of
 	// Hive on cluster doesn't yet support it)
-	if cd.Status.PowerState != "" && cd.Status.PowerState == "Running" {
+	if cd.Status.PowerState == "Running" {
 		return true
 	}
 
@@ -638,16 +631,7 @@ func instancesAreRunning(cd hivev1.ClusterDeployment) bool {
 	}
 
 	// Check legacy Hibernation condition reasons
-	return validHibernationReason(hibernatingCondition.Reason)
-}
-
-func validHibernationReason(lookup string) bool {
-	for _, val := range validHibernationReasons {
-		if val == lookup {
-			return true
-		}
-	}
-	return false
+	return hibernatingCondition.Reason == legacyHivev1RunningHibernationReason
 }
 
 func getCondition(conditions []hivev1.ClusterDeploymentCondition, t hivev1.ClusterDeploymentConditionType) *hivev1.ClusterDeploymentCondition {

--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
@@ -142,11 +142,45 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 		},
 	}
 	cd.Spec.Installed = true
+	cd.Status.PowerState = hivev1.RunningReadyReason
 	cd.Status.Conditions = []hivev1.ClusterDeploymentCondition{
 		{
 			Type:   hivev1.ClusterHibernatingCondition,
 			Status: corev1.ConditionFalse,
 			Reason: hivev1.ResumingOrRunningHibernationReason,
+		},
+	}
+
+	return &cd
+}
+
+func testLegacyClusterDeployment() *hivev1.ClusterDeployment {
+	labelMap := map[string]string{config.ClusterDeploymentManagedLabel: "true"}
+	finalizers := []string{deadMansSnitchFinalizer}
+
+	cd := hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testClusterName,
+			Namespace:   testNamespace,
+			Labels:      labelMap,
+			Finalizers:  finalizers,
+			UID:         testUID,
+			Annotations: map[string]string{},
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: testClusterName,
+			BaseDomain:  "base.domain",
+			ClusterMetadata: &hivev1.ClusterMetadata{
+				ClusterID: testExternalID,
+			},
+		},
+	}
+	cd.Spec.Installed = true
+	cd.Status.Conditions = []hivev1.ClusterDeploymentCondition{
+		{
+			Type:   hivev1.ClusterHibernatingCondition,
+			Status: corev1.ConditionFalse,
+			Reason: legacyHivev1RunningHibernationReason,
 		},
 	}
 
@@ -330,6 +364,39 @@ func TestReconcileClusterDeployment(t *testing.T) {
 			name: "Test Creating",
 			localObjects: []runtime.Object{
 				testClusterDeployment(),
+				testSecret(),
+				testDeadMansSnitchIntegration(),
+			},
+			expectedSyncSets: &SyncSetEntry{
+				name:                     testClusterName + "-" + snitchNamePostFix + "-" + config.RefSecretPostfix,
+				referencedSecretName:     testClusterName + "-" + snitchNamePostFix + "-" + config.RefSecretPostfix,
+				clusterDeploymentRefName: testClusterName,
+			},
+			expectedSecret: &SecretEntry{
+				name:                     testClusterName + "-" + snitchNamePostFix + "-" + config.RefSecretPostfix,
+				snitchURL:                testSnitchURL,
+				clusterDeploymentRefName: testClusterName,
+			},
+			verifySyncSets: verifySyncSetExists,
+			verifySecret:   verifySecretExists,
+			setupDMSMock: func(r *mockdms.MockClientMockRecorder) {
+				r.Create(gomock.Any()).Return(dmsclient.Snitch{CheckInURL: testSnitchURL, Tags: []string{testTag}}, nil).Times(1)
+				r.FindSnitchesByName(gomock.Any()).Return([]dmsclient.Snitch{}, nil).Times(1)
+				r.FindSnitchesByName(gomock.Any()).Return([]dmsclient.Snitch{
+					{
+						CheckInURL: testSnitchURL,
+						Status:     "pending",
+					},
+				}, nil).Times(2)
+				r.CheckIn(gomock.Any()).Return(nil).Times(1)
+				r.Update(gomock.Any()).Times(0)
+				r.Delete(gomock.Any()).Times(0)
+			},
+		},
+		{
+			name: "Test Creating Legacy Hibernation condition on ClusterDeployment",
+			localObjects: []runtime.Object{
+				testLegacyClusterDeployment(),
 				testSecret(),
 				testDeadMansSnitchIntegration(),
 			},


### PR DESCRIPTION
We can now rely on the ClusterDeployment Status field `PowerState` to determine if a cluster is running or not, this field was introduced in https://github.com/openshift/hive/pull/1604

We only check legacy conditions if that field doesn't exist which may be because the running version of Hive does not yet contain support for that field. 

We are removing checking legacy Hibernation condition reason `Resuming` because during that state the cluster is not "Running" and may not check in with Deadmanssnitch causing erroneous alerts.

[OSD-9349](https://issues.redhat.com/browse/OSD-9349)