### PR TITLE
Logr uses constant messages and key value pairs, no string formatting

### DIFF
--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -129,16 +129,16 @@ func (r *ReconcileDeadmansSnitchIntegration) Reconcile(request reconcile.Request
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling DeadmansSnitchIntegration")
 
-	//FEDRAMP environment variable defaulting to false.
+	//FedRAMP environment variable defaulting to false.
 	fedramp := false
 	if fedrampVar, ok := os.LookupEnv("FEDRAMP"); ok {
 		fedramp, err := strconv.ParseBool(fedrampVar)
 		if err != nil {
-			reqLogger.Info("Unable to parse FEDRAMP environment variable. defaulting to %b.", fedramp)
+			reqLogger.Info("Unable to parse FedRAMP environment variable", "Default value:", fedramp)
 		}
-		reqLogger.Info("running in FedRAMP environment: %b", fedramp)
+		reqLogger.Info("Running in FedRAMP", "FedRAMP environment", fedramp)
 	} else {
-		reqLogger.Info("FedRAMP environment variable unset, defaulting to %b", fedramp)
+		reqLogger.Info("FedRAMP environment variable unset", "Default value", fedramp)
 	}
 
 	// Fetch the DeadmansSnitchIntegration dmsi


### PR DESCRIPTION
Logr uses a constant message and then a key value pair, the current implementation of the `Info()` messages for the FedRAMP var cause an error on every reconcile.

```
{"level":"dpanic","ts":1642711642.4362042,"logger":"controller_deadmanssnitchintegration","msg":"odd number of arguments passed as key-value pairs for logging","Request.Namespace":"deadmanssnitch-operator","Request.Name":"osd","ignored key":false,"stacktrace":"github.com/go-logr/zapr.handleFields\n\tpkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:100\ngithub.com/go-logr/zapr.(*zapLogger).Info\n\tpkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:127\ngithub.com/openshift/deadmanssnitch-operator/pkg/controller/deadmanssnitchintegration.(*ReconcileDeadmansSnitchIntegration).Reconcile\n\tsrc/github.com/openshift/deadmanssnitch-operator/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go:139\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\tpkg/mod/k8s.io/apimachinery@v0.20.0/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\tpkg/mod/k8s.io/apimachinery@v0.20.0/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tpkg/mod/k8s.io/apimachinery@v0.20.0/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\tpkg/mod/k8s.io/apimachinery@v0.20.0/pkg/util/wait/wait.go:90"}

```

I've cleaned up the messages a little and an example looks like:

`{"level":"info","ts":1642717247.4972236,"logger":"controller_deadmanssnitchintegration","msg":"Running in FedRAMP","Request.Namespace":"deadmanssnitch-operator","Request.Name":"test-dmsi","FedRAMP environment":false}`