### PR TITLE
Improve Fedramp Implementation

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -134,6 +134,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	err = operatorconfig.SetIsFedramp()
+	if err != nil {
+		log.Error(err, "Failed to get fedramp value")
+		os.Exit(1)
+	}
+	if operatorconfig.IsFedramp() {
+		log.Info("Running in fedramp environment.")
+	}
+
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,12 @@
 
 package config
 
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
 const (
 	OperatorName      string = "deadmanssnitch-operator"
 	OperatorNamespace string = "deadmanssnitch-operator"
@@ -25,3 +31,26 @@ const (
 	// if the cluster is OSD (managed) or not
 	ClusterDeploymentManagedLabel string = "api.openshift.com/managed"
 )
+
+var isFedramp = false
+
+// SetIsFedramp gets the value of fedramp
+func SetIsFedramp() error {
+	fedramp, ok := os.LookupEnv("FEDRAMP")
+	if !ok {
+		fedramp = "false"
+	}
+
+	fedrampBool, err := strconv.ParseBool(fedramp)
+	if err != nil {
+		return fmt.Errorf("Invalid value for FedRAMP environment variable. %w", err)
+	}
+
+	isFedramp = fedrampBool
+	return nil
+}
+
+// IsFedramp returns value of isFedramp var
+func IsFedramp() bool {
+	return isFedramp
+}

--- a/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/pkg/controller/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -3,8 +3,6 @@ package deadmanssnitchintegration
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/openshift/deadmanssnitch-operator/config"
 	deadmanssnitchv1alpha1 "github.com/openshift/deadmanssnitch-operator/pkg/apis/deadmanssnitch/v1alpha1"
@@ -129,16 +127,8 @@ func (r *ReconcileDeadmansSnitchIntegration) Reconcile(request reconcile.Request
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling DeadmansSnitchIntegration")
 
-	//FedRAMP environment variable defaulting to false.
-	fedramp := false
-	if fedrampVar, ok := os.LookupEnv("FEDRAMP"); ok {
-		fedramp, err := strconv.ParseBool(fedrampVar)
-		if err != nil {
-			reqLogger.Info("Unable to parse FedRAMP environment variable", "Default value:", fedramp)
-		}
-		reqLogger.Info("Running in FedRAMP", "FedRAMP environment", fedramp)
-	} else {
-		reqLogger.Info("FedRAMP environment variable unset", "Default value", fedramp)
+	if config.IsFedramp() {
+		reqLogger.Info("Running in FedRAMP mode")
 	}
 
 	// Fetch the DeadmansSnitchIntegration dmsi


### PR DESCRIPTION
Currently the fedramp variable value is not being check, causing log messages reading fedramp=true no matter what. PR ensures that:
- Log message reads fedramp only when fedramp=true
- Only check once at operator start up, instead of every reconcile loop for every clusterDeployment

Tested on stage cluster.