### PR TITLE
OSD-10026 : Update DMSI to not alert for 'limited-support' clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -83,6 +83,10 @@ objects:
       - key: api.openshift.com/channel-group
         operator: NotIn
         values: ["nightly"]
+      # ignore CD w/ limited-support label
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values: ["true"]
     targetSecretRef:
       name: dms-secret
       namespace: openshift-monitoring


### PR DESCRIPTION
In reference to [OSD-10026](https://issues.redhat.com/browse/OSD-10026)

PR for updating the DeadMansSnitch integration to delete a DMS service if the cluster is in limited support and hence, 
**To not page SRE**

