### PR TITLE
OSD-11299 Remove CPU limits and increase Memory limits to 2G

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,11 +22,10 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "800Mi"
-              cpu: "50m"
+              memory: "1G"
+              cpu: "100m"
             limits:
-              memory: "800Mi"
-              cpu: "50m"
+              memory: "2G"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Currently the pod is getting CPU throttled and OOM killed in production, so bumping these up for observation. Can potentially be tuned lower afterwards

```bash
❯ oc adm top po -n deadmanssnitch-operator
NAME                                       CPU(cores)   MEMORY(bytes)
deadmanssnitch-operator-5b9599dd65-5sljc   75m          791Mi
```