### PR TITLE
Revert monitoring limited support clusterdeployments

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -83,6 +83,10 @@ objects:
       - key: api.openshift.com/channel-group
         operator: NotIn
         values: ["nightly"]
+      # ignore CD w/ limited-support label
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values: ["true"]
     targetSecretRef:
       name: dms-secret
       namespace: openshift-monitoring


### PR DESCRIPTION
tl;dr reverts #146 

[OSD-12958](https://issues.redhat.com//browse/OSD-12958) We noticed a bug when rolling this out to production as CAD does not take into account previous (unrelated) limited support reasons. Since it's near the end of year change freeze, rolling back this change for now to investigate later