### PR TITLE
Enable watching clusterdeployments with limited-support label

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -83,10 +83,6 @@ objects:
       - key: api.openshift.com/channel-group
         operator: NotIn
         values: ["nightly"]
-      # ignore CD w/ limited-support label
-      - key: api.openshift.com/limited-support
-        operator: NotIn
-        values: ["true"]
     targetSecretRef:
       name: dms-secret
       namespace: openshift-monitoring


### PR DESCRIPTION
Revert https://github.com/openshift/deadmanssnitch-operator/commit/9a1a9278f8b40339092d937046935737705d7964 to watch clusterdeployments with limited-support label to allow configuration anomaly detection (CAD) to handle CHGM alerts

for [OSD-12958](https://issues.redhat.com//browse/OSD-12958)