### PR TITLE
OSD-13714 - Improving handling of multi-snitch potential cases

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -3,7 +3,7 @@ ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-1
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-3
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
Improving the handling of situation where potentially multiple snitches have been created for the same service (multiple integration with same postfix, potential partial retrieve from DMS service, ...) : 
- initial implementation was potentially trying to validate a snitch which wasn't the one identified as 'Pending' (as using result of 2 different retrieve and DMS doesn't guarantee the ordering)
- in case of multiple snitches, we could potentially never try to activate some of the snitches

Underlying JIRA Card : [OSD-13714](https://issues.redhat.com/browse/OSD-13714)