### PR TITLE
OSD-19710: no snitch for limited support clusters unless supportex

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/deadmanssnitch-operator
 ENV GOFLAGS=""
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 ENV OPERATOR_BIN=deadmanssnitch-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -88,6 +88,63 @@ objects:
       - key: api.openshift.com/fedramp
         operator: NotIn
         values: ["true"]
+      # Ignore CD if cluster is in limited support
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values: ["true"]
+      # ignore CD if cluster has a support exception, 
+      # as we have a dedicated dms integration for supportex that ignores limited support
+      - key: ext-managed.openshift.io/support-exception
+        operator: NotIn
+        values: ["true"]
+    targetSecretRef:
+      name: dms-secret
+      namespace: openshift-monitoring
+    tags: ${{DEADMANSSNITCH_OSD_TAGS}}
+    clusterDeploymentAnnotationsToSkip:
+    - name: hive.openshift.io/fake-cluster
+      value: "true"
+    - name: managed.openshift.com/fake
+      value: "true"
+
+- apiVersion: deadmanssnitch.managed.openshift.io/v1alpha1
+  kind: DeadmansSnitchIntegration
+  metadata:
+    name: osd-supportex
+  spec:
+    snitchNamePostFix: ""
+    dmsAPIKeySecretRef:
+      name: deadmanssnitch-api-key
+      namespace: deadmanssnitch-operator
+    clusterDeploymentSelector:
+      matchExpressions:
+      # only create DMS service for managed (OSD) clusters
+      - key: api.openshift.com/managed
+        operator: In
+        values: ["true"]
+      # ignore CD w/ "legacy" noalerts label
+      - key: api.openshift.com/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD w/ ext noalerts label
+      - key: ext-managed.openshift.io/noalerts
+        operator: NotIn
+        values: ["true"]
+      # ignore CD for specific organizations
+      - key: api.openshift.com/legal-entity-id
+        operator: NotIn
+        values: ${{SILENT_ALERT_LEGALENTITY_IDS}}
+      # ignore CD for any "nightly" clusters
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values: ["nightly"]
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values: ["true"]
+      # Only create DMS service for clusters with a support exception
+      - key: ext-managed.openshift.io/support-exception
+        operator: In
+        values: ["true"]
     targetSecretRef:
       name: dms-secret
       namespace: openshift-monitoring


### PR DESCRIPTION
This is a followup of the recent refactor done in configuration-anomaly-detection (https://github.com/openshift/configuration-anomaly-detection/pull/246).

With the most recent CAD refactor, we no longer need [the workaround](https://github.com/openshift/deadmanssnitch-operator/pull/149) to handle "resolving" pagerduty alerts, thus don't need to route alerts for clusters that are in limited support through CAD. Therefore, we can disable the snitches for clusters that are in limited support. However, with the recent addition of support exceptions, we still need to handle alerts regardless of the cluster's support state.

This PR disables snitches for clusters that are in limited support **unless they have a support exception**, thus allowing a full transparent flow for CAD. 

Tested scenarios on staging:

- Out of limited support, no supportex =  dms integration
- In limited support, no supportex = no dms integration
- In limited support, supportex (ext-managed.openshift.io/support-exception cd label) = dms integration
- Out of limited support, supportex (ext-managed.openshift.io/support-exception cd label) = dms integration