### PR TITLE
Bumping ubi-minimal to push through quay.io scan

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/deadmanssnitch-operator
 ENV GOFLAGS=""
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741795396
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 ENV OPERATOR_BIN=deadmanssnitch-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741795396
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
Looks like Quay's vulnerability scanner has the latest commit stuck in a queue. ~When this has happened in the past, a dummy commit solved things.~ edit: had to bump ubi-minimal version to pass validation test, so this PR is no longer purely dummy