### PR TITLE
SREP-811 - Add team Rocket as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ reviewers:
 approvers:
 - robotmaxtron
 - rafael-azevedo
+- srep-functional-team-rocket
 - srep-functional-leads
 - srep-team-leads
 maintainers:


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-811

---

Adds team Rocket as approvers, in order to fulfill their responsibilities as Observability domain owners.