### PR TITLE
SREP-811 - Ensure dependabot does not attempt to update boilerplate images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# BEGIN boilerplate-managed
 version: 2
 updates:
   - package-ecosystem: "docker"
@@ -8,7 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "app-sre/boilerplate"
+      - dependency-name: "redhat-services-prod/openshift/boilerplate"
         # don't upgrade boilerplate via these means
       - dependency-name: "openshift4/ose-operator-registry"
         # don't upgrade ose-operator-registry via these means
+# END boilerplate-managed


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-811

---

Updates `dependabot.yml`'s `ignore` block to omit boilerplate images from auto-updating