### PR TITLE
chore(SREP-4514): Enable CodeRabbit inheritance for repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,10 @@
+inheritance: true
+reviews:
+  path_filters:
+    # Exclude build artifacts and dependencies
+    - "!build/**"
+    - "!.venv/**"
+
+    # Exclude test fixtures
+    - "!**/testdata/**"
+    - "!**/.test-fixtures/**"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/deadmanssnitch-operator
 ENV GOFLAGS=""
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
 ENV OPERATOR_BIN=deadmanssnitch-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
## Summary
- Enable CodeRabbit inheritance and configure path filters for build artifacts, dependencies, and test fixtures

Rebased from #290 onto current master to pick up the boilerplate update (PR #291), which was causing the `validate` CI job to fail due to stale UBI base image tags in the Dockerfiles.

Original author: @devppratik (commit authored by them, committer is @clcollins)

## Test plan
- [ ] CI passes (validate job should now succeed with current boilerplate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to refine the review process by excluding build artifacts, dependencies, and test fixtures from consideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->