### PR TITLE
[TESTING- do not merge] Add agentic SDLC conformance check pipeline (ROSA-730)

### DIFF
--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -31,7 +31,6 @@ spec:
           steps:
             - name: clone-and-check
               image: alpine/git:latest
-              onError: continue
               workingDir: $(workspaces.source.path)
               script: |
                 #!/usr/bin/env sh

--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -20,32 +20,89 @@ metadata:
 spec:
   pipelineSpec:
     tasks:
-      - name: agentic-sdlc-check
+      - name: clone-repository
+        params:
+          - name: url
+            value: '{{source_url}}'
+          - name: revision
+            value: '{{revision}}'
+        taskRef:
+          params:
+            - name: name
+              value: git-clone
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:39efcb7d049d84feccce65e589996a89b19ab7c9f504015c3792e3daee697da3
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: output
+            workspace: workspace
+          - name: basic-auth
+            workspace: git-auth
+      - name: check-file-existence
+        runAfter:
+          - clone-repository
         taskSpec:
-          workspaces:
-            - name: source
-              description: Workspace for cloning and checking repository source
-            - name: git-auth
-              description: Git credentials for authenticated clone
-              optional: true
           steps:
-            - name: clone-and-check
-              image: alpine/git:latest
-              workingDir: $(workspaces.source.path)
+            - name: check-files
+              image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+              workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env sh
                 set -eu
 
-                # ── Clone ──
-                if [ -d "$(workspaces.git-auth.path)" ] 2>/dev/null; then
-                  cp "$(workspaces.git-auth.path)/.gitconfig" ~/.gitconfig 2>/dev/null || true
-                  cp "$(workspaces.git-auth.path)/.git-credentials" ~/.git-credentials 2>/dev/null || true
-                fi
-                git clone '{{source_url}}' source
-                cd source
-                git checkout '{{revision}}'
+                PASS=0
+                FAIL=0
 
-                # ── Conformance Check ──
+                pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+                fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+                echo "=== Agentic SDLC Conformance: File Existence (ROSA-730) ==="
+                echo "Repository: $(basename $(pwd))"
+                echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                echo ""
+
+                if [ -f "CLAUDE.md" ]; then pass "CLAUDE.md exists"; else fail "CLAUDE.md missing"; fi
+                if [ -f ".pre-commit-config.yaml" ]; then pass ".pre-commit-config.yaml exists"; else fail ".pre-commit-config.yaml missing"; fi
+                if [ -f ".codecov.yml" ]; then pass ".codecov.yml exists"; else fail ".codecov.yml missing"; fi
+                if [ -f "CONTRIBUTING.md" ]; then pass "CONTRIBUTING.md exists"; else fail "CONTRIBUTING.md missing"; fi
+                if [ -f "DEVELOPMENT.md" ]; then pass "DEVELOPMENT.md exists"; else fail "DEVELOPMENT.md missing"; fi
+                if [ -f "TESTING.md" ]; then pass "TESTING.md exists"; else fail "TESTING.md missing"; fi
+
+                if [ -f "CLAUDE.md" ]; then
+                  if [ -f ".claude/settings.json" ]; then pass ".claude/settings.json exists"; else fail ".claude/settings.json missing (CLAUDE.md present but no Claude hooks)"; fi
+                fi
+
+                if [ -d "boilerplate/openshift/golang-osd-operator" ]; then
+                  if [ -f "boilerplate/openshift/golang-osd-operator/golangci.yml" ]; then pass "golangci.yml exists (boilerplate convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-osd-operator/"; fi
+                elif [ -d "boilerplate/openshift/golang-lint" ]; then
+                  if [ -f "boilerplate/openshift/golang-lint/golangci.yml" ]; then pass "golangci.yml exists (golang-lint convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-lint/"; fi
+                else
+                  if [ -f ".golangci.yml" ] || [ -f ".golangci.yaml" ]; then pass "golangci config exists at repo root"; else fail "golangci config missing (no boilerplate dir and no root .golangci.yml/.yaml)"; fi
+                fi
+
+                echo ""
+                TOTAL=$((PASS + FAIL))
+                echo "File existence: $PASS / $TOTAL passed"
+                if [ "$FAIL" -gt 0 ]; then exit 1; fi
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
+      - name: check-content-validation
+        runAfter:
+          - clone-repository
+        taskSpec:
+          steps:
+            - name: check-content
+              image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+              workingDir: $(workspaces.source.path)/source
+              script: |
+                #!/usr/bin/env sh
+                set -eu
+
                 PASS=0
                 FAIL=0
                 WARN=0
@@ -54,85 +111,12 @@ spec:
                 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
                 warn() { echo "WARN: $1"; WARN=$((WARN + 1)); }
 
-                echo "=== Agentic SDLC Conformance Report (ROSA-730) ==="
+                echo "=== Agentic SDLC Conformance: Content Validation (ROSA-730) ==="
                 echo "Repository: $(basename $(pwd))"
                 echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
                 echo ""
 
-                # ── File Existence ──
-
-                echo "── File Existence ──"
-
-                if [ -f "CLAUDE.md" ]; then
-                  pass "CLAUDE.md exists"
-                else
-                  fail "CLAUDE.md missing"
-                fi
-
-                if [ -f ".pre-commit-config.yaml" ]; then
-                  pass ".pre-commit-config.yaml exists"
-                else
-                  fail ".pre-commit-config.yaml missing"
-                fi
-
-                if [ -f ".codecov.yml" ]; then
-                  pass ".codecov.yml exists"
-                else
-                  fail ".codecov.yml missing"
-                fi
-
-                if [ -f "CONTRIBUTING.md" ]; then
-                  pass "CONTRIBUTING.md exists"
-                else
-                  fail "CONTRIBUTING.md missing"
-                fi
-
-                if [ -f "DEVELOPMENT.md" ]; then
-                  pass "DEVELOPMENT.md exists"
-                else
-                  fail "DEVELOPMENT.md missing"
-                fi
-
-                if [ -f "TESTING.md" ]; then
-                  pass "TESTING.md exists"
-                else
-                  fail "TESTING.md missing"
-                fi
-
-                if [ -f "CLAUDE.md" ]; then
-                  if [ -f ".claude/settings.json" ]; then
-                    pass ".claude/settings.json exists"
-                  else
-                    fail ".claude/settings.json missing (CLAUDE.md present but no Claude hooks)"
-                  fi
-                fi
-
-                if [ -d "boilerplate/openshift/golang-osd-operator" ]; then
-                  if [ -f "boilerplate/openshift/golang-osd-operator/golangci.yml" ]; then
-                    pass "golangci.yml exists (boilerplate convention)"
-                  else
-                    fail "golangci.yml missing from boilerplate/openshift/golang-osd-operator/"
-                  fi
-                elif [ -d "boilerplate/openshift/golang-lint" ]; then
-                  if [ -f "boilerplate/openshift/golang-lint/golangci.yml" ]; then
-                    pass "golangci.yml exists (golang-lint convention)"
-                  else
-                    fail "golangci.yml missing from boilerplate/openshift/golang-lint/"
-                  fi
-                else
-                  if [ -f ".golangci.yml" ] || [ -f ".golangci.yaml" ]; then
-                    pass "golangci config exists at repo root"
-                  else
-                    fail "golangci config missing (no boilerplate dir and no root .golangci.yml/.yaml)"
-                  fi
-                fi
-
-                echo ""
-
-                # ── Content Validation ──
-
-                echo "── Content Validation ──"
-
+                # CLAUDE.md required sections
                 if [ -f "CLAUDE.md" ]; then
                   claude_content=$(cat CLAUDE.md)
 
@@ -153,8 +137,11 @@ spec:
                   else
                     fail "CLAUDE.md missing architecture/overview section"
                   fi
+                else
+                  fail "CLAUDE.md not found — skipping content checks"
                 fi
 
+                # .codecov.yml patch coverage target
                 if [ -f ".codecov.yml" ]; then
                   patch_target=$(grep -A5 'patch:' .codecov.yml | grep 'target:' | head -1 | grep -oE '[0-9]+' | head -1)
                   if [ -n "$patch_target" ]; then
@@ -168,6 +155,7 @@ spec:
                   fi
                 fi
 
+                # .pre-commit-config.yaml required hooks
                 if [ -f ".pre-commit-config.yaml" ]; then
                   pcf_content=$(cat .pre-commit-config.yaml)
 
@@ -190,6 +178,7 @@ spec:
                   fi
                 fi
 
+                # Documentation files must not be stubs
                 for doc in CONTRIBUTING.md DEVELOPMENT.md TESTING.md; do
                   if [ -f "$doc" ]; then
                     line_count=$(wc -l < "$doc")
@@ -202,31 +191,18 @@ spec:
                 done
 
                 echo ""
-
-                # ── Summary ──
-
                 TOTAL=$((PASS + FAIL + WARN))
-                echo "=== Summary ==="
-                echo "PASS: $PASS / $TOTAL"
-                echo "FAIL: $FAIL / $TOTAL"
-                if [ "$WARN" -gt 0 ]; then
-                  echo "WARN: $WARN / $TOTAL"
-                fi
-                echo ""
-
+                echo "Content validation: $PASS passed, $FAIL failed, $WARN warnings out of $TOTAL checks"
                 if [ "$FAIL" -gt 0 ]; then
-                  echo "STATUS: NON-CONFORMANT ($FAIL issues found)"
+                  echo ""
                   echo "See ROSA-730 for agentic SDLC standards: https://issues.redhat.com/browse/ROSA-730"
                   exit 1
-                else
-                  echo "STATUS: CONFORMANT"
-                  exit 0
                 fi
+          workspaces:
+            - name: source
         workspaces:
           - name: source
             workspace: workspace
-          - name: git-auth
-            workspace: git-auth
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
             value: '{{source_url}}'
           - name: revision
             value: '{{revision}}'
+          - name: subdirectory
+            value: source
         taskRef:
           params:
             - name: name

--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -1,0 +1,253 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/deadmanssnitch-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'true'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: deadmanssnitch-operator
+    appstudio.openshift.io/component: deadmanssnitch-operator
+    pipelines.appstudio.openshift.io/type: test
+  name: deadmanssnitch-operator-agentic-sdlc-check
+  namespace: deadmanssnitch-operator-tenant
+spec:
+  pipelineSpec:
+    tasks:
+      - name: clone-repository
+        params:
+          - name: url
+            value: '{{source_url}}'
+          - name: revision
+            value: '{{revision}}'
+        taskRef:
+          params:
+            - name: name
+              value: git-clone
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0d76f429b730ee7f1b9dab0e7e05f47d5aca498c4dc143de2293db1f7c735e02
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: output
+            workspace: workspace
+          - name: basic-auth
+            workspace: git-auth
+      - name: agentic-sdlc-check
+        runAfter:
+          - clone-repository
+        taskSpec:
+          workspaces:
+            - name: source
+              description: Workspace containing the cloned repository source code
+          steps:
+            - name: check-conformance
+              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              onError: continue
+              workingDir: $(workspaces.source.path)/source
+              script: |
+                #!/usr/bin/env bash
+                set -uo pipefail
+
+                PASS=0
+                FAIL=0
+                WARN=0
+
+                pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+                fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+                warn() { echo "WARN: $1"; WARN=$((WARN + 1)); }
+
+                echo "=== Agentic SDLC Conformance Report (ROSA-730) ==="
+                echo "Repository: $(basename $(pwd))"
+                echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                echo ""
+
+                # ── Section 1: File Existence ──
+
+                echo "── File Existence ──"
+
+                if [ -f "CLAUDE.md" ]; then
+                  pass "CLAUDE.md exists"
+                else
+                  fail "CLAUDE.md missing"
+                fi
+
+                if [ -f ".pre-commit-config.yaml" ]; then
+                  pass ".pre-commit-config.yaml exists"
+                else
+                  fail ".pre-commit-config.yaml missing"
+                fi
+
+                if [ -f ".codecov.yml" ]; then
+                  pass ".codecov.yml exists"
+                else
+                  fail ".codecov.yml missing"
+                fi
+
+                if [ -f "CONTRIBUTING.md" ]; then
+                  pass "CONTRIBUTING.md exists"
+                else
+                  fail "CONTRIBUTING.md missing"
+                fi
+
+                if [ -f "DEVELOPMENT.md" ]; then
+                  pass "DEVELOPMENT.md exists"
+                else
+                  fail "DEVELOPMENT.md missing"
+                fi
+
+                if [ -f "TESTING.md" ]; then
+                  pass "TESTING.md exists"
+                else
+                  fail "TESTING.md missing"
+                fi
+
+                if [ -f "CLAUDE.md" ]; then
+                  if [ -f ".claude/settings.json" ]; then
+                    pass ".claude/settings.json exists"
+                  else
+                    fail ".claude/settings.json missing (CLAUDE.md present but no Claude hooks)"
+                  fi
+                fi
+
+                if [ -d "boilerplate/openshift/golang-osd-operator" ]; then
+                  if [ -f "boilerplate/openshift/golang-osd-operator/golangci.yml" ]; then
+                    pass "golangci.yml exists (boilerplate convention)"
+                  else
+                    fail "golangci.yml missing from boilerplate/openshift/golang-osd-operator/"
+                  fi
+                elif [ -d "boilerplate/openshift/golang-lint" ]; then
+                  if [ -f "boilerplate/openshift/golang-lint/golangci.yml" ]; then
+                    pass "golangci.yml exists (golang-lint convention)"
+                  else
+                    fail "golangci.yml missing from boilerplate/openshift/golang-lint/"
+                  fi
+                else
+                  if [ -f ".golangci.yml" ] || [ -f ".golangci.yaml" ]; then
+                    pass "golangci config exists at repo root"
+                  else
+                    fail "golangci config missing (no boilerplate dir and no root .golangci.yml/.yaml)"
+                  fi
+                fi
+
+                echo ""
+
+                # ── Section 2: Content Validation ──
+
+                echo "── Content Validation ──"
+
+                if [ -f "CLAUDE.md" ]; then
+                  claude_content=$(cat CLAUDE.md)
+
+                  if echo "$claude_content" | grep -qiE '##.*(build commands|development commands|build|dev server)'; then
+                    pass "CLAUDE.md has build/development commands section"
+                  else
+                    fail "CLAUDE.md missing build/development commands section"
+                  fi
+
+                  if echo "$claude_content" | grep -qiE '##.*(agent rules|agents must|agent)'; then
+                    pass "CLAUDE.md has agent rules section"
+                  else
+                    warn "CLAUDE.md missing agent rules section (recommended heading: 'Agent Rules')"
+                  fi
+
+                  if echo "$claude_content" | grep -qiE '##.*(architecture|project overview|what this operator does|overview)'; then
+                    pass "CLAUDE.md has architecture/overview section"
+                  else
+                    fail "CLAUDE.md missing architecture/overview section"
+                  fi
+                fi
+
+                if [ -f ".codecov.yml" ]; then
+                  patch_target=$(grep -A5 'patch:' .codecov.yml | grep 'target:' | head -1 | grep -oE '[0-9]+' | head -1)
+                  if [ -n "$patch_target" ]; then
+                    if [ "$patch_target" -ge 50 ]; then
+                      pass ".codecov.yml patch coverage target is ${patch_target}% (>= 50%)"
+                    else
+                      fail ".codecov.yml patch coverage target is ${patch_target}% (should be >= 50%)"
+                    fi
+                  else
+                    warn ".codecov.yml patch coverage target could not be parsed"
+                  fi
+                fi
+
+                if [ -f ".pre-commit-config.yaml" ]; then
+                  pcf_content=$(cat .pre-commit-config.yaml)
+
+                  if echo "$pcf_content" | grep -q 'gitleaks'; then
+                    pass ".pre-commit-config.yaml includes gitleaks (secrets detection)"
+                  else
+                    fail ".pre-commit-config.yaml missing gitleaks hook"
+                  fi
+
+                  if echo "$pcf_content" | grep -q 'golangci-lint'; then
+                    pass ".pre-commit-config.yaml includes golangci-lint"
+                  else
+                    fail ".pre-commit-config.yaml missing golangci-lint hook"
+                  fi
+
+                  if echo "$pcf_content" | grep -qE '(check-yaml|check-merge-conflict)'; then
+                    pass ".pre-commit-config.yaml includes file hygiene hooks"
+                  else
+                    fail ".pre-commit-config.yaml missing file hygiene hooks (check-yaml or check-merge-conflict)"
+                  fi
+                fi
+
+                for doc in CONTRIBUTING.md DEVELOPMENT.md TESTING.md; do
+                  if [ -f "$doc" ]; then
+                    line_count=$(wc -l < "$doc")
+                    if [ "$line_count" -gt 10 ]; then
+                      pass "$doc has substantive content (${line_count} lines)"
+                    else
+                      fail "$doc appears to be a stub (${line_count} lines, expected > 10)"
+                    fi
+                  fi
+                done
+
+                echo ""
+
+                # ── Summary ──
+
+                TOTAL=$((PASS + FAIL + WARN))
+                echo "=== Summary ==="
+                echo "PASS: $PASS / $TOTAL"
+                echo "FAIL: $FAIL / $TOTAL"
+                if [ "$WARN" -gt 0 ]; then
+                  echo "WARN: $WARN / $TOTAL"
+                fi
+                echo ""
+
+                if [ "$FAIL" -gt 0 ]; then
+                  echo "STATUS: NON-CONFORMANT ($FAIL issues found)"
+                  echo "See ROSA-730 for agentic SDLC standards: https://issues.redhat.com/browse/ROSA-730"
+                  exit 1
+                else
+                  echo "STATUS: CONFORMANT"
+                  exit 0
+                fi
+        workspaces:
+          - name: source
+            workspace: workspace
+    workspaces:
+      - name: workspace
+      - name: git-auth
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -29,33 +29,24 @@ spec:
               description: Git credentials for authenticated clone
               optional: true
           steps:
-            - name: clone
-              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+            - name: clone-and-check
+              image: alpine/git:latest
+              onError: continue
               workingDir: $(workspaces.source.path)
-              env:
-                - name: GIT_AUTH_PATH
-                  value: $(workspaces.git-auth.path)
               script: |
-                #!/usr/bin/env bash
-                set -euo pipefail
-                microdnf install -y git-core 2>/dev/null
-                if [ -f "${GIT_AUTH_PATH}/.gitconfig" ]; then
-                  cp "${GIT_AUTH_PATH}/.gitconfig" ~/.gitconfig
-                fi
-                if [ -f "${GIT_AUTH_PATH}/.git-credentials" ]; then
-                  cp "${GIT_AUTH_PATH}/.git-credentials" ~/.git-credentials
+                #!/usr/bin/env sh
+                set -eu
+
+                # ── Clone ──
+                if [ -d "$(workspaces.git-auth.path)" ] 2>/dev/null; then
+                  cp "$(workspaces.git-auth.path)/.gitconfig" ~/.gitconfig 2>/dev/null || true
+                  cp "$(workspaces.git-auth.path)/.git-credentials" ~/.git-credentials 2>/dev/null || true
                 fi
                 git clone '{{source_url}}' source
                 cd source
                 git checkout '{{revision}}'
-            - name: check-conformance
-              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
-              onError: continue
-              workingDir: $(workspaces.source.path)/source
-              script: |
-                #!/usr/bin/env bash
-                set -uo pipefail
 
+                # ── Conformance Check ──
                 PASS=0
                 FAIL=0
                 WARN=0
@@ -69,7 +60,7 @@ spec:
                 echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
                 echo ""
 
-                # ── Section 1: File Existence ──
+                # ── File Existence ──
 
                 echo "── File Existence ──"
 
@@ -139,7 +130,7 @@ spec:
 
                 echo ""
 
-                # ── Section 2: Content Validation ──
+                # ── Content Validation ──
 
                 echo "── Content Validation ──"
 
@@ -155,7 +146,7 @@ spec:
                   if echo "$claude_content" | grep -qiE '##.*(agent rules|agents must|agent)'; then
                     pass "CLAUDE.md has agent rules section"
                   else
-                    warn "CLAUDE.md missing agent rules section (recommended heading: 'Agent Rules')"
+                    warn "CLAUDE.md missing agent rules section (recommended heading: Agent Rules)"
                   fi
 
                   if echo "$claude_content" | grep -qiE '##.*(architecture|project overview|what this operator does|overview)'; then

--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -20,34 +20,34 @@ metadata:
 spec:
   pipelineSpec:
     tasks:
-      - name: clone-repository
-        params:
-          - name: url
-            value: '{{source_url}}'
-          - name: revision
-            value: '{{revision}}'
-        taskRef:
-          params:
-            - name: name
-              value: git-clone
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0d76f429b730ee7f1b9dab0e7e05f47d5aca498c4dc143de2293db1f7c735e02
-            - name: kind
-              value: task
-          resolver: bundles
-        workspaces:
-          - name: output
-            workspace: workspace
-          - name: basic-auth
-            workspace: git-auth
       - name: agentic-sdlc-check
-        runAfter:
-          - clone-repository
         taskSpec:
           workspaces:
             - name: source
-              description: Workspace containing the cloned repository source code
+              description: Workspace for cloning and checking repository source
+            - name: git-auth
+              description: Git credentials for authenticated clone
+              optional: true
           steps:
+            - name: clone
+              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: GIT_AUTH_PATH
+                  value: $(workspaces.git-auth.path)
+              script: |
+                #!/usr/bin/env bash
+                set -euo pipefail
+                microdnf install -y git-core 2>/dev/null
+                if [ -f "${GIT_AUTH_PATH}/.gitconfig" ]; then
+                  cp "${GIT_AUTH_PATH}/.gitconfig" ~/.gitconfig
+                fi
+                if [ -f "${GIT_AUTH_PATH}/.git-credentials" ]; then
+                  cp "${GIT_AUTH_PATH}/.git-credentials" ~/.git-credentials
+                fi
+                git clone '{{source_url}}' source
+                cd source
+                git checkout '{{revision}}'
             - name: check-conformance
               image: registry.access.redhat.com/ubi9/ubi-minimal:latest
               onError: continue
@@ -235,6 +235,8 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
+          - name: git-auth
+            workspace: git-auth
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
+++ b/.tekton/deadmanssnitch-operator-agentic-sdlc-check-pull-request.yaml
@@ -18,6 +18,8 @@ metadata:
   name: deadmanssnitch-operator-agentic-sdlc-check
   namespace: deadmanssnitch-operator-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-deadmanssnitch-operator
   pipelineSpec:
     tasks:
       - name: clone-repository


### PR DESCRIPTION
## Summary

- Adds a Konflux pipeline that validates [ROSA-730](https://redhat.atlassian.net/browse/ROSA-730) agentic SDLC standards on every PR
- Non-conformant repos see a **red X** on the PR — visible signal without blocking merge
- Non-blocking because the check name is not in `required_status_checks` (prow config), so `/lgtm` + `/approve` still merge via tide
- Pilot deployment to validate the check before rolling out to all ROSA operator repos via [boilerplate PR #788](https://github.com/openshift/boilerplate/pull/788)

## What it checks

### File existence (parallel task)
- `CLAUDE.md`, `.pre-commit-config.yaml`, `.codecov.yml`
- `CONTRIBUTING.md`, `DEVELOPMENT.md`, `TESTING.md`
- `.claude/settings.json` (if `CLAUDE.md` exists)
- `golangci.yml` (in boilerplate convention dir or repo root)

### Content validation (parallel task)
- `CLAUDE.md` has required sections (build commands, architecture/overview)
- `.codecov.yml` patch coverage target >= 50%
- `.pre-commit-config.yaml` includes gitleaks, golangci-lint, file hygiene hooks
- Documentation files are substantive (> 10 lines, not stubs)

## Expected behavior on this repo

This repo is currently **partially conformant** — the check reports failures for missing `CONTRIBUTING.md`, `DEVELOPMENT.md`, `TESTING.md`, and `.claude/settings.json`. The pipeline fails (red X) but does not block merge.

## Test plan

- [x] Verify the pipeline runs on this PR
- [x] Confirm clone-repository succeeds, check tasks run in parallel and report correct failures
- [x] Confirm failures appear as red X in PR checks but do NOT block merge via tide
- [ ] If successful, roll out to remaining ROSA operator repos via boilerplate

[ROSA-730](https://redhat.atlassian.net/browse/ROSA-730)

🤖 Generated with [Claude Code](https://claude.com/claude-code)