### PR TITLE
fix: prevent cross-namespace secret read via DmsAPIKeySecretRef

### DIFF
--- a/controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -98,8 +98,12 @@ func (r *DeadmansSnitchIntegrationReconciler) Reconcile(ctx context.Context, req
 	// set the DMS finalizer variable
 	deadMansSnitchFinalizer := DeadMansSnitchFinalizerPrefix + dmsi.Name
 
+	// Always read from the operator's own namespace regardless of what DmsAPIKeySecretRef.Namespace
+	// says. Using the CR-supplied namespace would allow any principal with create on
+	// DeadmansSnitchIntegration to exfiltrate arbitrary Secrets via the operator's
+	// cluster-wide secret-read privilege (CWE-441 confused-deputy, ROSAENG-61327).
 	dmsAPIKey, err := utils.LoadSecretData(r.Client, dmsi.Spec.DmsAPIKeySecretRef.Name,
-		dmsi.Spec.DmsAPIKeySecretRef.Namespace, deadMansSnitchAPISecretKey)
+		config.OperatorNamespace, deadMansSnitchAPISecretKey)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
+++ b/controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller.go
@@ -102,6 +102,9 @@ func (r *DeadmansSnitchIntegrationReconciler) Reconcile(ctx context.Context, req
 	// says. Using the CR-supplied namespace would allow any principal with create on
 	// DeadmansSnitchIntegration to exfiltrate arbitrary Secrets via the operator's
 	// cluster-wide secret-read privilege (CWE-441 confused-deputy, ROSAENG-61327).
+	// NOTE: DmsAPIKeySecretRef.Namespace is intentionally ignored here and is effectively
+	// dead code. A follow-up PR should change the field type from corev1.SecretReference
+	// to corev1.LocalObjectReference to remove it from the API entirely.
 	dmsAPIKey, err := utils.LoadSecretData(r.Client, dmsi.Spec.DmsAPIKeySecretRef.Name,
 		config.OperatorNamespace, deadMansSnitchAPISecretKey)
 	if err != nil {

--- a/controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
+++ b/controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go
@@ -757,3 +757,76 @@ func verifyNoSecret(c client.Client, expected *SecretEntry) bool {
 
 	return true
 }
+
+// TestCrossNamespaceSecretRefRejected verifies ROSAENG-61327: a DMSI whose
+// DmsAPIKeySecretRef.Namespace points to a foreign namespace must not cause the
+// operator to read that secret. The operator must always look up the API key in
+// config.OperatorNamespace, ignoring whatever namespace the CR author specifies.
+func TestCrossNamespaceSecretRefRejected(t *testing.T) {
+	err := deadmanssnitchv1alpha1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	err = hiveapis.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+
+	const foreignNamespace = "foreign-namespace"
+
+	// Secret exists only in the foreign namespace, NOT in config.OperatorNamespace.
+	foreignSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deadMansSnitchAPISecretName,
+			Namespace: foreignNamespace,
+		},
+		Data: map[string][]byte{
+			deadMansSnitchAPISecretKey: []byte(testAPIKey),
+		},
+	}
+
+	// DMSI points DmsAPIKeySecretRef at the foreign namespace — the attack vector.
+	dmsi := &deadmanssnitchv1alpha1.DeadmansSnitchIntegration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDeadMansSnitchintegrationName,
+			Namespace: config.OperatorNamespace,
+		},
+		Spec: deadmanssnitchv1alpha1.DeadmansSnitchIntegrationSpec{
+			DmsAPIKeySecretRef: corev1.SecretReference{
+				Name:      deadMansSnitchAPISecretName,
+				Namespace: foreignNamespace,
+			},
+			ClusterDeploymentSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{config.ClusterDeploymentManagedLabel: "true"},
+			},
+			TargetSecretRef: corev1.SecretReference{
+				Name:      "test-secret",
+				Namespace: testNamespace,
+			},
+		},
+	}
+
+	mocks := setupDefaultMocks(t, []k8sruntime.Object{
+		testClusterDeployment(),
+		foreignSecret,
+		dmsi,
+	})
+	defer mocks.mockCtrl.Finish()
+
+	rdms := &DeadmansSnitchIntegrationReconciler{
+		Client: mocks.fakeKubeClient,
+		Scheme: scheme.Scheme,
+		dmsclient: func(apiKey string, collector *localmetrics.MetricsCollector) dmsclient.Client {
+			return mocks.mockDMSClient
+		},
+	}
+
+	_, reconcileErr := rdms.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testDeadMansSnitchintegrationName,
+			Namespace: config.OperatorNamespace,
+		},
+	})
+
+	// Must fail with NotFound: the secret only exists in foreignNamespace, not in
+	// config.OperatorNamespace. If the operator used DmsAPIKeySecretRef.Namespace it
+	// would succeed and exfiltrate the foreign secret to api.deadmanssnitch.com.
+	assert.Error(t, reconcileErr, "reconcile should fail when DmsAPIKeySecretRef points to a foreign namespace")
+	assert.True(t, errors.IsNotFound(reconcileErr), "expected NotFound — secret must not be readable from a foreign namespace")
+}


### PR DESCRIPTION
## Summary

Fixes ROSAENG-61327 with a minimal, targeted change.

`DmsAPIKeySecretRef` is a `corev1.SecretReference` (Name + Namespace). The reconciler was passing the CR-supplied `Namespace` directly to `utils.LoadSecretData`, which uses the operator's cluster-wide secret-read privilege. Any principal with `create` on `DeadmansSnitchIntegration` could set `DmsAPIKeySecretRef.Namespace` to point at any namespace (e.g. hive credentials, cloud-provider creds) and have the operator transmit that secret to `api.deadmanssnitch.com` — a confused-deputy attack (CWE-441, CWE-639, CWE-200, CVSS 7.7).

**Fix:** one line in the controller — pass `config.OperatorNamespace` to `LoadSecretData` instead of the CR-supplied namespace. All production DMSI CRs already set `namespace: deadmanssnitch-operator`, so there is no behaviour change for legitimate use.

## Changes

- `controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller.go` — use `config.OperatorNamespace` (1 line)
- `controllers/deadmanssnitchintegration/deadmanssnitchintegration_controller_test.go` — add `TestCrossNamespaceSecretRefRejected`: places the secret only in a foreign namespace, asserts reconcile returns `NotFound`, proving the cross-namespace read path is closed

## Test plan

- [x] `go test ./controllers/deadmanssnitchintegration/...` — all existing tests pass, new security regression test passes
- [x] No behaviour change for production DMSI CRs (all set `dmsAPIKeySecretRef.namespace: deadmanssnitch-operator`)

Fixes: ROSAENG-61327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened secret handling so the integration now only reads the API key from the operator’s own namespace.
  * Requests that reference a secret in another namespace will now fail instead of being accepted, reducing the risk of unintended cross-namespace access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->