### PR TITLE
chore: bump ubi9/ubi-minimal to 1782797355 (CVE fixes)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/deadmanssnitch-operator
 ENV GOFLAGS=""
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797355
 ENV OPERATOR_BIN=deadmanssnitch-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797355
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
## Summary

Bumps `ubi9/ubi-minimal` from `9.8-1782797275` → `1782797355` in `build/Dockerfile` and `build/Dockerfile.olm-registry` to pick up the latest RHEL 9 security patches and trigger a fresh image build.

### CVEs addressed

| CVE / RHSA | Severity | Component | Status |
|---|---|---|---|
| RHSA-2024:8860 | Important (CVSS 9.0) | krb5-libs | Fixed via UBI base image bump |
| RHSA-2025:2686 | Important (CVSS 8.1) | libxml2 | Fixed via UBI base image bump |
| CVE-2024-24786 | Important (CVSS 7.5) | google.golang.org/protobuf | Already at v1.36.11 in go.mod; new build publishes updated digest |

### CVEs requiring separate action

The following CVEs affect the `registry-server` binary embedded in `ose-operator-registry-rhel9:v4.21` and cannot be fixed by a base image bump alone:

| CVE | Severity | Component | Fix version |
|---|---|---|---|
| CVE-2024-45337 | Critical (CVSS 9.1) | golang.org/x/crypto | ≥ 0.31.0 |
| CVE-2025-22869 | Important (CVSS 7.5) | golang.org/x/crypto | ≥ 0.35.0 |

These will be resolved when Red Hat ships an updated `ose-operator-registry-rhel9` image with the patched Go crypto library.

### JIRA tickets
- https://redhat.atlassian.net/browse/ROSAENG-58756
- https://redhat.atlassian.net/browse/ROSAENG-58759
- https://redhat.atlassian.net/browse/ROSAENG-58760

## Test plan
- [ ] Confirm CI builds pass
- [ ] Verify new `quay.io/app-sre/deadmanssnitch-operator` digest no longer triggers ACS CVE policy for RHSA-2024:8860 / RHSA-2025:2686 / CVE-2024-24786
- [ ] Deploy new image to hivep08ue2 and confirm ACS violations for [ROSAENG-58756](https://redhat.atlassian.net/browse/ROSAENG-58756) clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)