### PR TITLE
Scope ClusterRole to least-privilege verbs and resources

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/deadmanssnitch-operator
 ENV GOFLAGS=""
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 ENV OPERATOR_BIN=deadmanssnitch-operator
 
 WORKDIR /root/

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
@@ -22,6 +29,7 @@ rules:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -36,6 +44,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ""
   resources:
@@ -78,6 +87,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -7,29 +7,41 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -54,16 +66,41 @@ rules:
   resources:
   - syncsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:
-  - '*'
+  - deadmanssnitchintegrations
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/finalizers
+  verbs:
+  - update

--- a/deploy_pko/.test-fixtures/default/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,28 +10,41 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -56,16 +69,41 @@ rules:
   resources:
   - syncsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:
-  - '*'
+  - deadmanssnitchintegrations
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/finalizers
+  verbs:
+  - update

--- a/deploy_pko/.test-fixtures/default/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,6 +10,13 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get
@@ -25,6 +32,7 @@ rules:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ''
   resources:
@@ -39,6 +47,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -81,6 +90,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:

--- a/deploy_pko/.test-fixtures/empty-silent-ids/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-silent-ids/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,28 +10,41 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -56,16 +69,41 @@ rules:
   resources:
   - syncsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:
-  - '*'
+  - deadmanssnitchintegrations
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/finalizers
+  verbs:
+  - update

--- a/deploy_pko/.test-fixtures/empty-silent-ids/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/.test-fixtures/empty-silent-ids/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,6 +10,13 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get
@@ -25,6 +32,7 @@ rules:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ''
   resources:
@@ -39,6 +47,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -81,6 +90,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,28 +10,41 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -56,16 +69,41 @@ rules:
   resources:
   - syncsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:
-  - '*'
+  - deadmanssnitchintegrations
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/finalizers
+  verbs:
+  - update

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,6 +10,13 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get
@@ -25,6 +32,7 @@ rules:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ''
   resources:
@@ -39,6 +47,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -81,6 +90,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:

--- a/deploy_pko/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,28 +10,41 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - ''
   resources:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  verbs:
-  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -56,16 +69,41 @@ rules:
   resources:
   - syncsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - create
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:
-  - '*'
+  - deadmanssnitchintegrations
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - deadmanssnitch.managed.openshift.io
+  resources:
+  - deadmanssnitchintegrations/finalizers
+  verbs:
+  - update

--- a/deploy_pko/ClusterRole-deadmanssnitch-operator.yaml
+++ b/deploy_pko/ClusterRole-deadmanssnitch-operator.yaml
@@ -10,6 +10,13 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get
@@ -25,6 +32,7 @@ rules:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - ''
   resources:
@@ -39,6 +47,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ''
   resources:
@@ -81,6 +90,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - deadmanssnitch.managed.openshift.io
   resources:


### PR DESCRIPTION
## Summary
- The operator ClusterRole used wildcard (`*`) verbs on core resources (pods, services, endpoints, persistentvolumeclaims, events, configmaps, secrets), apps resources (deployments, daemonsets), hive syncsets, and routes — far broader than what the controller actually exercises.
- Replaced all wildcard verbs with the minimal set actually needed per resource, based on code analysis of the controller, event handlers, leader election, and metrics setup.
- Dropped resources the controller never touches: `pods`, `endpoints`, `persistentvolumeclaims`, `deployments`, `daemonsets`.
- Enumerated `deadmanssnitch.managed.openshift.io` CRD permissions explicitly (matching kubebuilder markers) instead of wildcarding both resources and verbs.
- Applied the same changes to `deploy/role.yaml`, `deploy_pko/ClusterRole`, and all three PKO test fixtures.

### Permission mapping

| Resource | Verbs | Reason |
|---|---|---|
| secrets | get, list, watch, create, delete | API key read, per-cluster snitch secrets, watch triggers |
| configmaps | get, create, update, delete | Leader election lock (deleteLeader removes lock on NotReady node) |
| events | create, patch | Controller-runtime event recorder |
| pods | get, delete | Leader election (operator-lib leader.Become reads own pod, deleteLeader deletes evicted pods) |
| services | get, create, update | Custom metrics endpoint (operator-custom-metrics create-or-update) |
| namespaces | get | _(unchanged)_ |
| syncsets | get, list, watch, create, delete | SyncSet CRUD + watch triggers |
| routes | get, create, update | Custom metrics endpoint (operator-custom-metrics create-or-update) |
| servicemonitors | get, create | _(unchanged)_ |
| clusterdeployments/* | get, list, watch, update, patch | _(unchanged)_ |
| deadmanssnitchintegrations | full CRUD | Own CRD |

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] PKO test fixtures updated and validated
- [x] Verify operator starts without RBAC errors on a test cluster
- [x] Verify reconciliation still creates/deletes secrets, syncsets, and snitches correctly

[ROSAENG-61322](https://redhat.atlassian.net/browse/ROSAENG-61322)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened operator access controls by limiting permissions to required resources and actions.
  * Removed unnecessary access to workloads, endpoints, and persistent storage resources.
  * Applied more precise permissions for synchronization, routing, and monitoring integrations.
  * Existing integrations and synchronization workflows continue to function with a reduced security footprint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->